### PR TITLE
Publish to registry 

### DIFF
--- a/aws-functions/aws-functions.sentinel
+++ b/aws-functions/aws-functions.sentinel
@@ -1,0 +1,345 @@
+# Common functions for use with the AWS provider
+
+##### Imports #####
+import "tfconfig-functions" as config
+import "tfplan/v2" as tfplan
+import "tfconfig/v2" as tfconfig
+import "strings"
+import "types"
+
+##### Functions #####
+
+### find_resources_with_standard_tags. if empty array is sent, then it will send all resources ###
+find_resources_with_standard_tags = func(resource_types) {
+	resources = filter tfplan.resource_changes as address, rc {
+		rc.provider_name matches "(.*)aws$" and
+			rc.mode is "managed" and
+			(rc.change.actions contains "create" or rc.change.actions contains "update" or
+				rc.change.actions contains "read" or
+				rc.change.actions contains "no-op") and
+			(resource_types is empty or rc.type in resource_types)
+	}
+
+	return resources
+}
+
+### determine_role_arn ###
+# This can only determine the role_arn if it is set to either a hard-coded value
+# or to a reference to a single Terraform variable.
+# It sets the role to "complex" if it finds a single non-variable reference
+# or if it finds multiple references.
+# It sets the role to "none" if no role arn is found.
+determine_role_arn = func(address, data) {
+
+	# Return empty string if provider does not assume a role
+	role_arn_value = "none"
+
+	# Check for role_arn
+	if (length(data.config) else 0) > 0 and
+		(length(data.config.assume_role) else 0) > 0 and
+		data.config.assume_role[0].role_arn else null is not null {
+		role_arn_data = data.config.assume_role[0].role_arn
+		# Check for constant value or references
+		if role_arn_data.constant_value else null is not null {
+			# role_arn of AWS provider was hard-coded role_arn
+			#print("Found a single constant value for role_arn.")
+			role_arn_value = role_arn_data.constant_value
+		} else if role_arn_data.references else [] is not [] {
+			if length(role_arn_data.references) == 1 {
+				# Process references
+				role_arn = role_arn_data.references[0]
+				if role_arn matches "var\\.(.*)" {
+					# role_arn of AWS provider was a variable
+					#print("Found a single variable reference for role_arn.")
+					role_arn_variable = strings.trim_prefix(role_arn, "var.")
+					role_arn_value = tfplan.variables[role_arn_variable].value
+				} else {
+					# reference was not a variable
+					print("Found a single reference in the role_arn attribute,",
+						"for provider", address, "but it was not a variable.")
+					print("This policy only handles a role_arn attribute that is",
+						"a constant value or a single reference to a variable.")
+					# Set role_arn_value to null to cause failure of policy
+					role_arn_value = "complex"
+				} // end if role_arn is variable
+			} else {
+				print("Found more than one reference in the role_arn attribute",
+					"for provider", address)
+				print("This policy only handles a role_arn attribute that is",
+					"a constant value or a single reference to a variable.")
+				# Set role_arn_value to null to cause failure of policy
+				role_arn_value = "complex"
+			} // end if single reference
+		} // end if constant_value or references
+	} else {
+		#print("Did not find role_arn.")
+	} // end if assume_role.role_arn in config
+
+	return role_arn_value
+}
+
+### get_assumed_roles ###
+# Get assumed roles from all AWS providers
+# Please note that the assumed roles returned could include "none" or "complex";
+# See the comments for the determine_role_arn function above.
+get_assumed_roles = func() {
+
+	# Initialize empty map of roles indexed by aliases
+	assumed_roles = {}
+
+	# Get all AWS provider aliases
+	aws_providers = config.find_providers_by_type("aws")
+
+	# Iterate through all AWS provider aliases
+	for aws_providers as address, data {
+		assumed_roles[address] = determine_role_arn(address, data)
+	} // end aws_providers
+
+	return assumed_roles
+
+}
+
+### validate_assumed_roles_with_list ###
+# Validate that all assumed roles are allowed.
+# If you want to the policy to pass if an assumed role contains a single
+# non-variable reference or if it finds multiple references, then include a role
+# called "complex" in the allowed_roles list.
+validate_assumed_roles_with_list = func(allowed_roles) {
+
+	validated = true
+
+	assumed_roles = get_assumed_roles()
+
+	for assumed_roles as address, role {
+		if role is not "none" and role not in allowed_roles {
+			print("AWS provider", address, "has assumed role",
+				role, "that is not allowed.")
+			validated = false
+		}
+	}
+
+	return validated
+}
+
+### validate_assumed_roles_with_map ###
+# Validate that all assumed roles are allowed for the current workspace.
+# If you want to a policy to pass if an assumed role contains a single
+# non-variable reference or if it finds multiple references, then include a role
+# called "complex" in the map passed to this function and associate it
+# with workspaces.
+validate_assumed_roles_with_map = func(roles_map, workspace_name) {
+
+	validated = true
+
+	assumed_roles = get_assumed_roles()
+
+	for assumed_roles as address, role {
+		if role is not "none" {
+			if role not in keys(roles_map) {
+				print("AWS provider", address, "has assumed role",
+					role, "that is not allowed.")
+				validated = false
+			} else {
+				# Validate that role is allowed for current workspace
+				matched = false
+				for roles_map[role] as workspace_regex {
+					if workspace_name matches workspace_regex {
+						matched = true
+					}
+				} // end for workspace_regex
+				if not matched {
+					print("Workspace", workspace_name, "is not allowed to use role", role)
+					print("It used that role in the AWS provider", address)
+					validated = false
+				} // end matched check
+			} // end role in roles_map
+		} // end if role is not ""
+	} // end for assumed_roles
+
+	return validated
+}
+
+### filter_providers_by_regions ###
+# Filter instances of the AWS provider to those in a specific region using the
+# tfconfig/v2 and tfplan/v2 imports.
+# See the comments on the validate_provider_in_allowed_regions() function below
+# for details on how this is done.
+# The parameter, aws_providers, should be a list of AWS provider aliases
+# derived from tfconfig.providers.
+# The parameter, allowed_regions, should be given as a list of AWS regions
+# such as `["us-east-1" and "eu-west-2"]`.
+filter_providers_by_regions = func(aws_providers, allowed_regions) {
+
+	# Initialize empty list of validated AWS provider instances
+	validated_providers = {}
+
+	# Process  AWS providers
+	for aws_providers as index, p {
+		if "config" in keys(p) and "region" in keys(p.config) {
+			# provider alias has a region
+			validated = validate_provider_in_allowed_regions(p, allowed_regions)
+			if validated {
+				print("validated provider:", index)
+				validated_providers[index] = p
+			}
+		} else {
+			# provider alias does not have region
+			# So, we process it as an alias to a root module provider
+			# A provider that does not have its own region should look like
+			# <module_address>:<provider>.<alias>
+			# we want to look at <provider>.<alias>
+			p_segments = strings.split(p.provider_config_key, ":")
+			if length(p_segments) == 1 {
+				# Current provider is already in root module
+				# So, it is not an alias to another provider
+				# Continue on to next resource in for loop
+				continue
+			}
+			# Get the provider in root module that current provider aliases
+			p_alias_name = p_segments[1]
+			p_alias = tfconfig.providers[p_alias_name] else null
+
+			# Process p_alias
+			if p_alias is not null {
+				validated = validate_provider_in_allowed_regions(p_alias, allowed_regions)
+				if validated {
+					print("validated provider:", index)
+					validated_providers[index] = p
+				}
+			} // end p_alias not null
+		} // end else no region
+	} // end for
+
+	# return validated providers
+	return validated_providers
+
+}
+
+### validate_provider_in_allowed_regions ###
+# Validate if a specific provider instance is in a list of regions using the # tfconfig/v2 and tfplan/v2 iimports.
+# The parameter, p, should be a provider derived from tfconfig.providers
+# or from provider_config_key of a resource from tfconfig.resources.
+# The parameter, regions, should be given as a list of allowed regions
+
+# It attempts to identify the region of the provider aliases in several ways
+# including constant values assigned to their `region` argument and resolution
+# of references to variables. It first tries to process references to variables
+# as strings, then as maps with a key called "region". It handles references
+# to variables in the root module by using tfplan.variables. It handles references
+# to variables in non-root modules by examining the module call from the current
+# module's parent.
+
+# It even tries to match provider aliases in proxy configuration blocks
+# (which do not specify regions) of child modules to similarly-named provider
+# aliases in the root module.
+
+# If the alias passed in the module call does not match the alias in the root
+# module, Sentinel has no way of linking the two provider aliases. However,
+# since all providers that do specify regions will be restricted and since
+# provider alias proxies must point to other provider aliases in ancestor modules,
+# all provider aliases should be restricted by this policy.
+validate_provider_in_allowed_regions = func(p, regions) {
+	if "config" in keys(p) and "region" in keys(p.config) {
+		# provider has its own region
+		if "constant_value" in keys(p.config.region) {
+			if p.config.region.constant_value in regions {
+				# Found resource from region
+				return true
+			} else {
+				return false
+			}
+		} else if "references" in keys(p.config.region) {
+			# Iterate over references in region
+			# Usually, there should only be one reference
+			for p.config.region.references as reference {
+				# Cross reference variables
+				# Note that this function does not handle other types of references
+				if strings.has_prefix(reference, "var.") {
+					variable_name = strings.split(reference, ".")[1]
+					if p.module_address is "" {
+						# Get root module variable from tfplan.variables
+						variable_value = tfplan.variables[variable_name].value
+						# Check type of variable
+						variable_type = types.type_of(variable_value)
+						if variable_type is "string" and variable_value in regions {
+							# Found resource from region
+							return true
+						} else if variable_type is "map" and
+							"region" in keys(variable_value) and
+							variable_value["region"] in regions {
+							# Found resource from region
+							return true
+						} // end variable_type check
+					} else {
+						# Get non-root module variable
+						# Could be value passed into variable by module call
+						# or be the default value of a variable in the module
+
+						# First find parent module
+						module_segments = strings.split(p.module_address, ".")
+						num_segments = length(module_segments)
+						parent_module = strings.join(module_segments[0 : num_segments - 2], ".")
+						current_module_name = module_segments[num_segments - 1]
+
+						# Find module call that called current module
+						if parent_module is "" {
+							# parent module is root module
+							mc = tfconfig.module_calls[current_module_name]
+						} else {
+							# parent module is not root module
+							mc = tfconfig.module_calls[parent_module + ":" + current_module_name]
+						}
+
+						# Check if referenced variable was passed in the module call
+						if variable_name in keys(mc.config) {
+							mc_var = mc.config[variable_name]
+							if "constant_value" in keys(mc_var) {
+								if mc_var.constant_value in regions {
+									# Found resource from region
+									return true
+								} else {
+									return false
+								}
+							} else if "references" in keys(mc_var) and parent_module is "" {
+								// Check root module variable references
+								for mc_var.references as mc_reference {
+									if strings.has_prefix(mc_reference, "var.") {
+										mc_variable_name = strings.split(mc_reference, ".")[1]
+										mc_variable_value = tfplan.variables[mc_variable_name].value
+										mc_variable_type = types.type_of(mc_variable_value)
+										if mc_variable_type is "string" and mc_variable_value in regions {
+											# Found resource from region
+											return true
+										} else if mc_variable_type is "map" and
+											"region" in keys(mc_variable_value) and
+											mc_variable_value["region"] in regions {
+											# Found resource from region
+											return true
+										} // end mc_variable_type check
+									} // end if mc_reference is a root module variable
+								} // end for mc_var.references
+							} // end constant_value or references in module call
+						} else {
+							# check default value of variable in current module
+							default_value = tfconfig.variables[variable_name].default
+							default_value_type = types.type_of(default_value)
+							if default_value_type is "string" and default_value in regions {
+								# Found resource from region
+								return true
+							} else if default_value_type is "map" and
+								"region" in keys(default_value) and
+								default_value["region"] in regions {
+								# Found resource from region
+								return true
+							}
+						} // end if matched variable in module config or default value
+					} // end else non-root module
+				} // end reference is a variable
+			} // end for references
+		} // end references
+	} // end if p has config.region
+
+	# If we did not already return true, then return false
+	return false
+
+}

--- a/aws-functions/docs/determine_role_arn.md
+++ b/aws-functions/docs/determine_role_arn.md
@@ -1,0 +1,34 @@
+# determine_role_arn
+This function determines the ARN of an AWS IAM role assumed by the Terraform AWS provider using the [tfconfig/v2](https://www.terraform.io/docs/cloud/sentinel/import/tfconfig-v2.html) and [tfplan/v2](https://www.terraform.io/docs/cloud/sentinel/import/tfplan-v2.html) imports.
+
+It can only do this when the `role_arn` of the AWS provider is set to a hard-coded string or to a variable within the Terraform configuration. In the second case, the function cross-references the name of the variable in the tfconfig/v2 import with the actual value assigned to it in the tfplan/v2 import.
+
+## Sentinel Module
+This function is contained in the [aws-functions.sentinel](../aws-functions.sentinel) module.
+
+## Declaration
+`determine_role_arn = func(address, data)`
+
+## Arguments
+* **address**: the address of the provider which has the form `module_address:provider.alias`.
+* **data**: the data associated with the provider.
+
+## Common Functions Used
+None
+
+## What It Returns
+This function returns the ARN of the AWS IAM role of the provider. However, if no role was specified for an instance of the AWS provider, it returns "none", and if it finds finds a single non-variable reference or multiple references, it returns "complex".
+
+## What It Prints
+This function prints warning messages if the `role_arn` attribute was not a hard-coded string or a reference to a single variable.
+
+## Examples
+Here is an example of calling this function, assuming that the [tfconfig-functions.sentinel](../../../common-functions/tfconfig-functions/tfconfig-functions.sentinel) module has been imported with the alias `config`:
+```
+aws_providers = config.find_providers_by_type("aws")
+for aws_providers as address, data {
+  assumed_roles[address] = determine_role_arn(address, data)
+}
+```
+
+This function is called by the `get_assumed_roles` function contained in the same Sentinel module. In fact, the above code is extracted from that function. Since the two functions are in the same module, the call to the `get_assumed_roles` function does not include the `aws.` prefix.

--- a/aws-functions/docs/filter_providers_by_regions.md
+++ b/aws-functions/docs/filter_providers_by_regions.md
@@ -1,0 +1,33 @@
+# filter_providers_by_regions
+
+This function filters instances of the AWS provider to those in a specific region using the tfconfig/v2 and tfplan/v2 imports.
+
+See the documentation for the [validate_provider_in_allowed_regions](./validate_provider_in_allowed_regions.md) function for details on how this is done.
+
+## Sentinel Module
+This function is contained in the [aws-functions.sentinel](../aws-functions.sentinel) module.
+
+## Declaration
+`filter_providers_by_regions = func(aws_providers, allowed_regions)`
+
+## Arguments
+* **aws_providers**: a collection of instances of the AWS provider derived from tfconfig.providers.
+* **allowed_regions**: a list of AWS regions given as strings like `["us-east-1" and "eu-west-2"]`
+
+## Common Functions Used
+This function calls the the `validate_provider_in_allowed_regions` of the [aws-functions.sentinel](../aws-functions.sentinel) module.
+
+## What It Returns
+This function returns a single flat map of AWS providers. The map is actually a filtered sub-collection of the [`tfconfig.providers`](https://www.terraform.io/docs/cloud/sentinel/import/tfconfig-v2.html#the-resources-collection) collection.
+
+## What It Prints
+This function currently prints providers that are validated to assist evaluation of the function when used by customers. In the future, we might remove that printing.
+
+## Examples
+Here is an example of calling this function, assuming that the aws-functions.sentinel file that contains it has been imported with the alias `aws`:
+```
+validated_providers =
+            aws.filter_providers_by_regions(all_aws_providers, allowed_regions)
+```
+
+This function is used by the [validate-providers-from-desired-regions.sentinel](../../validate-providers-from-desired-regions.sentinel) policy.

--- a/aws-functions/docs/find_resources_with_standard_tags.md
+++ b/aws-functions/docs/find_resources_with_standard_tags.md
@@ -1,0 +1,41 @@
+# find_resources_with_standard_tags
+This function finds all AWS resource instances of specified types in the current plan that are not being permanently deleted using the [tfplan/v2](https://www.terraform.io/docs/cloud/sentinel/import/tfplan-v2.html) import.
+
+It was updated on 9/29/2020 to work with both the short name of the AWS provider, "aws", and fully-qualfied provider names that match the regex, `(.*)aws$`. This was required because Terraform 0.13 and above returns the fully-qualified names of providers such as "registry.terraform.io/hashicorp/aws" to Sentinel. Older versions of Terraform only return the short-form such as "aws".
+
+It was updated on 2/8/2021 to only look for tags in a given list of AWS
+resources instead of all AWS resources except those in a given list. We made
+this change because we discovered that there are many AWS resources that do
+not include standard AWS tags.
+
+## Sentinel Module
+This function is contained in the [aws-functions.sentinel](../aws-functions.sentinel) module.
+
+## Declaration
+`find_resources_with_standard_tags = func(resource_types)`
+
+## Arguments
+* **resource_types**: a list of AWS resource types that should have specified tags defined.
+
+## Common Functions Used
+None
+
+## What It Returns
+This function returns a single flat map of resource instances indexed by the complete [addresses](https://www.terraform.io/docs/internals/resource-addressing.html) of the instances. The map is actually a filtered sub-collection of the [`tfplan.resource_changes`](https://www.terraform.io/docs/cloud/sentinel/import/tfplan-v2.html#the-resource_changes-collection) collection.
+
+## What It Prints
+This function does not print anything.
+
+## Examples
+Here is an example of calling this function, assuming that the aws-functions.sentinel file that contains it has been imported with the alias `aws`:
+```
+resource_types = [
+  "aws_s3_bucket",
+  "aws_instance",
+]
+
+allAWSResourcesWithStandardTags =
+                          aws.find_resources_with_standard_tags(resource_types)
+```
+
+This function is used by the [enforce-mandatory-tags.sentinel](../../enforce-mandatory-tags.sentinel) policy.

--- a/aws-functions/docs/get_assumed_roles.md
+++ b/aws-functions/docs/get_assumed_roles.md
@@ -1,0 +1,30 @@
+# get_assumed_roles
+This function gets all roles assumed by any instances of the AWS provider in the current Terraform configuration using the [tfconfig/v2](https://www.terraform.io/docs/cloud/sentinel/import/tfconfig-v2.html) and [tfplan/v2](https://www.terraform.io/docs/cloud/sentinel/import/tfplan-v2.html) imports.
+
+The tfplan/v2 import is used by the `determine_role_arn` function that this function calls.
+
+## Sentinel Module
+This function is contained in the [aws-functions.sentinel](../aws-functions.sentinel) module.
+
+## Declaration
+`get_assumed_roles = func()`
+
+## Arguments
+None
+
+## Common Functions Used
+This function calls the `find_providers_by_type` function of the [tfconfig-functions.sentinel](../../../common-functions/tfconfig-functions/tfconfig-functions.sentinel) module and the `determine_role_arn` function of the [aws-functions.sentinel](../aws-functions.sentinel) module.
+
+## What It Returns
+This function returns a map indexed by the addresses of the provider instances contained in the workspace's Terraform configuration with values set to the actual ARNs of the AWS IAM roles assumed by those providers. However, if no role was specified for an instance of the AWS provider, it returns "none" for that instance, and if it finds finds a single non-variable reference or multiple references for an instance, it returns "complex" for that instance.
+
+## What It Prints
+This function does not print anything itself, but the `determine_role_arn` function prints warning messages if the `role_arn` attribute was not a hard-coded string or a reference to a single variable.
+
+## Examples
+Here is an example of calling this function:
+```
+assumed_roles = get_assumed_roles()
+```
+
+This function is called by the `validate_assumed_roles_with_list` and `validate_assumed_roles_with_map` functions contained in the same Sentinel module. Since the three functions are in the same module, the call to the `get_assumed_roles` function does not include the `aws.` prefix.

--- a/aws-functions/docs/validate_assumed_roles_with_list.md
+++ b/aws-functions/docs/validate_assumed_roles_with_list.md
@@ -1,0 +1,31 @@
+# validate_assumed_roles_with_list
+This function checks whether all roles assumed by all instances of the AWS provider in the current Terraform configuration are in a specified list.
+
+## Sentinel Module
+This function is contained in the [aws-functions.sentinel](../aws-functions.sentinel) module.
+
+## Declaration
+`validate_assumed_roles_with_list = func(allowed_roles)`
+
+## Arguments
+* **allowed_roles**: a list of allowed AWS IAM role ARNs that can be assumed by AWS providers. If you want to a policy that calls this function to pass if a role assumed by an instance of the AWS provider contains a single non-variable reference or multiple references, include "complex" in the list.
+
+## Common Functions Used
+This function calls the the `get_assumed_roles` function of the [aws-functions.sentinel](../aws-functions.sentinel) module.
+
+## What It Returns
+This function returns `true` if all the AWS IAM roles assumed by AWS providers in the Terraform configuration of the current workspace were in the `allowed_roles` list. Otherwise, it returns `false`.
+
+## What It Prints
+This function prints a warning message for each role assumed by an AWS provider that is not in the `allowed_roles` list.
+
+## Examples
+Here is an example of calling this function, assuming that the aws-functions.sentinel file that contains it has been imported with the alias `aws`:
+```
+allowed_roles = [
+  "arn:aws:iam::123412341234:role/terraform-assumed-role",
+]
+roles_validated = aws.validate_assumed_roles_with_list(allowed_roles)
+```
+
+This function is used by the [restrict-assumed-roles.sentinel](../../restrict-assumed-roles.sentinel) policy.

--- a/aws-functions/docs/validate_assumed_roles_with_map.md
+++ b/aws-functions/docs/validate_assumed_roles_with_map.md
@@ -1,0 +1,44 @@
+# validate_assumed_roles_with_map
+This function validates whether all roles assumed by instances of the AWS provider are allowed for the current workspace based on a map that maps AWS IAM roles to regular expressions (regex) that are compared to the name of the workspace.
+
+## Sentinel Module
+This function is contained in the [aws-functions.sentinel](../aws-functions.sentinel) module.
+
+## Declaration
+`validate_assumed_roles_with_map = func(roles_map, workspace_name)`
+
+## Arguments
+* **roles_map**: a map that associates AWS IAM role ARNs with lists of regular expressions (regex) that select workspace names that the role can be used in. If you want to a policy that calls this function to pass if a role assumed by an instance of the AWS provider contains a single non-variable reference or multiple references, include "complex" in the list.
+* **workspace_name**: the name of the workspace which can be derived from `tfrun.workspace.name`.
+
+## Common Functions Used
+This function calls the the `get_assumed_roles` function of the [aws-functions.sentinel](../aws-functions.sentinel) module.
+
+## What It Returns
+This function returns `true` if all the AWS IAM roles assumed by AWS providers in the Terraform configuration of the current workspace were keys in the `roles_map` map and the current workspace matched a regex in the lists assigned to values associated with those keys. Otherwise, it returns `false`.
+
+## What It Prints
+This function prints a warning message for each role assumed by an AWS provider that is not a key in `roles_map` or that is a key in that map but `workspace_name` does not match any regex in the list associated with it.
+
+## Examples
+Here is an example of calling this function, assuming that the aws-functions.sentinel file that contains it has been imported with the alias `aws`:
+```
+allowed_roles = {
+  "arn:aws:iam::123412341234:role/role-dev": [
+    "(.*)-dev$",
+    "^dev-(.*)",
+  ],
+  "arn:aws:iam::567856785678:role/role-qa": [
+    "(.*)-qa$",
+    "^qa-(.*)",
+  ],
+  "arn:aws:iam::909012349090:role/role-prod": [
+    "(.*)-prod$",
+    "^prod-(.*)",
+  ],
+}
+workspace_name = tfrun.workspace.name
+roles_validated = aws.validate_assumed_roles_with_map(allowed_roles, workspace_name)
+```
+
+This function is used by the [restrict-assumed-roles-by-workspace.sentinel](../../restrict-assumed-roles-by-workspace.sentinel) policy.

--- a/aws-functions/docs/validate_provider_in_allowed_regions.md
+++ b/aws-functions/docs/validate_provider_in_allowed_regions.md
@@ -1,0 +1,41 @@
+# validate_provider_in_allowed_regions
+This function validates whether a specific instance of the AWS provider is in a list of regions. The provider instance should be derived from `tfconfig.providers` or from the `provider_config_key` of a resource derived from `tfconfig.resources`.
+
+It attempts to identify the region of the provider aliases in several ways including constant values assigned to their `region` argument and resolution of references to variables. It first tries to process references to variables as strings, then as maps with a key called "region". It handles references to variables in the root module by using tfplan.variables. It handles references to variables in non-root modules by examining the module call from the current module's parent.
+
+It even tries to match provider aliases in proxy configuration blocks (which do not specify regions) of child modules to similarly-named provider aliases in the root module.
+
+If the alias passed in the module call does not match the alias in the root module, Sentinel has no way of linking the two provider aliases. However, since all providers that do specify regions will be restricted and since provider alias proxies must point to other provider aliases in ancestor modules, all provider aliases should be restricted by this policy.
+
+## Sentinel Module
+This function is contained in the [aws-functions.sentinel](../aws-functions.sentinel) module.
+
+## Declaration
+`validate_provider_in_allowed_regions = func(p, regions)`
+
+## Arguments
+* **p**: a specific alias of the AWS provider derived from `tfconfig.providers` or from the `provider_config_key` attribute of a resource derived from `tfconfig.resources`.
+* **regions**: a list of AWS AWS regions given as strings like `["us-east-1" and "eu-west-2"]`
+
+## Common Functions Used
+None
+
+## What It Returns
+This function returns a boolean indicating whether the provider alias was in one of the desired regions.
+
+## What It Prints
+This function does not print anything.
+
+## Examples
+Here is an example of calling this function, assuming that the aws-functions.sentinel file that contains it has been imported with the alias `aws`:
+```
+validated_providers = {}
+for aws_providers as index, p {
+  validated = validate_provider_in_allowed_regions(p, allowed_regions)
+  if validated {
+    validated_providers[index] = p
+  }
+}
+```
+
+This function is used by the `filter_providers_by_regions` function of the aws-functions module.

--- a/cloudtrail-encryption-must-be-enabled.sentinel
+++ b/cloudtrail-encryption-must-be-enabled.sentinel
@@ -1,0 +1,22 @@
+# This policy uses the Sentinel tfplan/v2 import to require that
+# all cloudtrail resource creations should have a KMS ID attached to it
+
+# Import common-functions/tfplan-functions/tfplan-functions.sentinel
+# with alias "plan"
+import "tfplan-functions" as plan
+
+# Get all cloudtrails
+allCloudtrails = plan.find_resources("aws_cloudtrail")
+
+# Filter to Cloudtrails that are not encrypted
+# Warnings will be printed for all violations since the last parameter is true
+
+nonEncryptedCloudTrails = plan.filter_attribute_does_not_have_prefix(allCloudtrails,
+	"kms_key_id",
+	"arn:aws:kms", false)
+
+# Main rule
+validated = length(nonEncryptedCloudTrails["messages"]) is 0
+main = rule {
+	validated is true
+}

--- a/common-functions/tfconfig-functions/docs/evaluate_attribute.md
+++ b/common-functions/tfconfig-functions/docs/evaluate_attribute.md
@@ -1,0 +1,29 @@
+# evaluate_attribute
+This function evaluates an attribute within an item in the Terraform configuration. The attribute must either be a top-level attribute or an attribute directly under "config".
+
+## Sentinel Module
+This function is contained in the [tfconfig-functions.sentinel](../tfconfig-functions.sentinel) module.
+
+## Declaration
+`evaluate_attribute = func(item, attribute)`
+
+## Arguments
+* **item**: a single item containing an attribute whose value you want to determine.
+* **attribute**: a string giving the attribute. In general, the attribute should be a top-level attribute of item, but it can also have the form "config.x".
+
+In practice, this function is only called by the filter functions, so the specification of the `attribute` parameter will be done when calling them.
+
+## Common Functions Used
+None.
+
+## What It Returns
+This function returns the attribute as it occurred within the Terraform configuration. The type will vary depending on what kind of attribute is evaluated. If the attribute had the form "config.x", it will look for "constant_value" or "references" under `item.config.x` and then whichever one it finds. In the latter case, it will return a list with all the references that the attribute referenced. Note that this does not evaluate the values of the references.
+
+## What It Prints
+This function does not print anything.
+
+## Examples
+This function is called by the `filter_attribute_does_not_match_regex` and `filter_attribute_matches_regex` filter functions in the tfconfig-functions.sentinel module like this:
+```
+val = evaluate_attribute(item, attr) else null
+```

--- a/common-functions/tfconfig-functions/docs/filter_attribute_does_not_match_regex.md
+++ b/common-functions/tfconfig-functions/docs/filter_attribute_does_not_match_regex.md
@@ -1,0 +1,33 @@
+# filter_attribute_does_not_match_regex
+This function filters a collection of items such as providers, provisioners, resources, data sources, variables, outputs, or module calls to those with an attribute that does not match a given regular expression (regex). A policy would call it when it wants the attribute to match that regex. The attribute must either be a top-level attribute or an attribute directly under "config".
+
+It uses the Sentinel [matches](https://docs.hashicorp.com/sentinel/language/spec/#matches-operator) operator which uses [RE2](https://github.com/google/re2/wiki/Syntax) regex.
+
+## Sentinel Module
+This function is contained in the [tfconfig-functions.sentinel](../tfconfig-functions.sentinel) module.
+
+## Declaration
+`filter_attribute_does_not_match_regex = func(items, attr, expr, prtmsg)`
+
+## Arguments
+* **items**: a map of items such as providers, provisioners, resources, data sources, variables, outputs, or module calls.
+* **attr**: the name of a top-level attribute or an attribute directly under "config". In the fist case, give the attribute as a string. In the second case, give it as "config.x" where "x" is the attribute you're trying to restrict.
+* **expr**: the regex expression that should not be matched. Note that any occurrences of `\` need to be escaped with `\` itself since Sentinel allows certain special characters to be escaped with `\`. For example, if you did not want to not match sub-domains of ".acme.com", you would set `expr` to `(.+)\\.acme\\.com$` instead of the more usual `(.+)\.acme\.com$`.
+* **prtmsg**: a boolean indicating whether violation messages should be printed (if `true`) or not (if `false`).
+
+## Common Functions Used
+This function calls the [evaluate_attribute](./evaluate_attribute.md) and the [to_string](./to_string.md) functions.
+
+## What It Returns
+This function returns a map with two maps, `items` and `messages`, both of which are indexed by the complete [addresses](https://www.terraform.io/docs/internals/resource-addressing.html) of the items that meet the condition of the filter function. The `items` map contains the actual resources for which the attribute (`attr`) does not match the given regex, `expr`, while the `messages` map contains the violation messages associated with those instances.
+
+## What It Prints
+This function prints the violation messages if the parameter, `prtmsg`, was set to `true`. Otherwise, it does not print anything.
+
+## Examples
+Here is an example of calling this function, assuming that the tfconfig-functions.sentinel file that contains it has been imported with the alias `config`:
+```
+violatingEC2Instances = config.filter_attribute_does_not_match_regex(allEC2Instances,
+                        "config.ami", "^data\\.aws_ami\\.(.*)$", true)
+```
+This is from the [require-most-recent-AMI-version.sentinel](../../../aws/require-most-recent-AMI-version.sentinel) policy.

--- a/common-functions/tfconfig-functions/docs/filter_attribute_in_list.md
+++ b/common-functions/tfconfig-functions/docs/filter_attribute_in_list.md
@@ -1,0 +1,40 @@
+# filter_attribute_in_list
+This function filters a collection of items such as providers, provisioners, resources, data sources, variables, outputs, or module calls to those with a top-level attribute that is contained in a provided list. A policy would call it when it wants the attribute to not have a value from the list.
+
+This function is intended to examine metadata of various Terraform objects within a Terraform configuration. It cannot be used to examine the values of attributes of resources or data sources. Use the filter functions of the tfplan-functions or tfstate-functions modules for that.
+
+## Sentinel Module
+This function is contained in the [tfconfig-functions.sentinel](../../tfconfig-functions.sentinel) module.
+
+## Declaration
+`filter_attribute_in_list = func(items, attr, forbidden, prtmsg)`
+
+## Arguments
+* **items**: a map of items such as providers, provisioners, resources, data sources, variables, outputs, or module calls.
+* **attr**: the name of a top-level attribute given as a string that must be in a given list. Nested attributes cannot be used by this function.
+* **forbidden**: a list of values the attribute is not allowed to have.
+* **prtmsg**: a boolean indicating whether violation messages should be printed (if `true`) or not (if `false`).
+
+## Common Functions Used
+This function calls the [to_string](./to_string.md) function.
+
+## What It Returns
+This function returns a map with two maps, `items` and `messages`. The `items` map contains the actual items of the original collection for which the attribute (`attr`) is in the list (`allowed`) while the `messages` map contains the violation messages associated with those items.
+
+## What It Prints
+This function prints the violation messages if the parameter, `prtmsg`, was set to `true`. Otherwise, it does not print anything.
+
+## Examples
+Here are some examples of calling this function, assuming that the tfconfig-functions.sentinel file that contains it has been imported with the alias `config`:
+```
+violatingProviders = config.filter_attribute_in_list(allProviders,
+                     "name", prohibited_list, false)
+
+violatingResources = config.filter_attribute_in_list(allResources,
+                     "type", prohibited_list, false)
+
+violatingProvisioners = config.filter_attribute_in_list(allProvisioners,
+                     "type", prohibited_list, false)
+```
+
+This function is used by several cloud-agnostic policies that prohibit certain types of items including [prohibited-datasources.sentinel](../../../cloud-agnostic/prohibited-datasources.sentinel), [prohibited-providers.sentinel](../../../cloud-agnostic/prohibited-providers.sentinel), [prohibited-provisioners.sentinel](../../../cloud-agnostic/prohibited-provisioners.sentinel), [require-all-providers-have-version-constrain.sentinel (Cloud Agnostic)](../../../cloud-agnostic/require-all-providers-have-version-constrain.sentinel) and [prohibited-resources.sentinel](../../../cloud-agnostic/prohibited-resources.sentinel).

--- a/common-functions/tfconfig-functions/docs/filter_attribute_matches_regex.md
+++ b/common-functions/tfconfig-functions/docs/filter_attribute_matches_regex.md
@@ -1,0 +1,32 @@
+# filter_attribute_matches_regex
+This function filters a collection of items such as resources, data sources, or blocks to those with an attribute that matches a given regular expression (regex). A policy would call it when it wants the attribute to not match that regex. The attribute must either be a top-level attribute or an attribute directly under "config".
+
+It uses the Sentinel [matches](https://docs.hashicorp.com/sentinel/language/spec/#matches-operator) operator which uses [RE2](https://github.com/google/re2/wiki/Syntax) regex.
+
+## Sentinel Module
+This function is contained in the [tfconfig-functions.sentinel](../tfconfig-functions.sentinel) module.
+
+## Declaration
+`filter_attribute_matches_regex = func(items, attr, expr, prtmsg)`
+
+## Arguments
+* **items**: a map of items such as providers, provisioners, resources, data sources, variables, outputs, or module calls.
+* **attr**: the name of a top-level attribute or an attribute directly under "config". In the fist case, give the attribute as a string. In the second case, give it as "config.x" where "x" is the attribute you're trying to restrict.
+* **expr**: the regex expression that should be matched. Note that any occurrences of `\` need to be escaped with `\` itself since Sentinel allows certain special characters to be escaped with `\`. For example, if you did not want to match sub-domains of ".acme.com", you would set `expr` to `(.+)\\.acme\\.com$` instead of the more usual `(.+)\.acme\.com$`. If you want to match null, set expr to "null".
+* **prtmsg**: a boolean indicating whether violation messages should be printed (if `true`) or not (if `false`).
+
+## Common Functions Used
+This function calls the [evaluate_attribute](./evaluate_attribute.md) and the [to_string](./to_string.md) functions.
+
+## What It Returns
+This function returns a map with two maps, `items` and `messages`, both of which are indexed by the complete [addresses](https://www.terraform.io/docs/internals/resource-addressing.html) of the items that meet the condition of the filter function. The `items` map contains the actual resources for which the attribute (`attr`) matches the given regex, `expr`, while the `messages` map contains the violation messages associated with those instances.
+
+## What It Prints
+This function prints the violation messages if the parameter, `prtmsg`, was set to `true`. Otherwise, it does not print anything.
+
+## Examples
+Here is an example of calling this function, assuming that the tfconfig-functions.sentinel file that contains it has been imported with the alias `config`:
+```
+violatingEC2Instances = config.filter_attribute_matches_regex(allEC2Instances,
+                        "config.ami", "^data\\.aws_ami\\.(.*)$", true)
+```

--- a/common-functions/tfconfig-functions/docs/filter_attribute_not_in_list.md
+++ b/common-functions/tfconfig-functions/docs/filter_attribute_not_in_list.md
@@ -1,0 +1,40 @@
+# filter_attribute_not_in_list
+This function filters a collection of items such as providers, provisioners, resources, data sources, variables, outputs, or module calls to those with a top-level attribute that is not contained in a provided list. A policy would call it when it wants the attribute to have a value from the list.
+
+This function is intended to examine metadata of various Terraform objects within a Terraform configuration. It cannot be used to examine the values of attributes of resources or data sources. Use the filter functions of the tfplan-functions or tfstate-functions modules for that.
+
+## Sentinel Module
+This function is contained in the [tfconfig-functions.sentinel](../../tfconfig-functions.sentinel) module.
+
+## Declaration
+`filter_attribute_not_in_list = func(items, attr, allowed, prtmsg)`
+
+## Arguments
+* **items**: a map of items such as providers, provisioners, resources, data sources, variables, outputs, or module calls.
+* **attr**: the name of a top-level attribute given as a string that must be in a given list. Nested attributes cannot be used by this function.
+* **allowed**: a list of values the attribute is allowed to have.
+* **prtmsg**: a boolean indicating whether violation messages should be printed (if `true`) or not (if `false`).
+
+## Common Functions Used
+This function calls the [to_string](./to_string.md) function.
+
+## What It Returns
+This function returns a map with two maps, `items` and `messages`. The `items` map contains the actual items of the original collection for which the attribute (`attr`) is not in the list (`allowed`) while the `messages` map contains the violation messages associated with those items.
+
+## What It Prints
+This function prints the violation messages if the parameter, `prtmsg`, was set to `true`. Otherwise, it does not print anything.
+
+## Examples
+Here are some examples of calling this function, assuming that the tfconfig-functions.sentinel file that contains it has been imported with the alias `config`:
+```
+violatingProviders = config.filter_attribute_not_in_list(allProviders,
+                     "name", allowed_list, false)
+
+violatingResources = config.filter_attribute_not_in_list(allResources,
+                     "type", allowed_list, false)
+
+violatingProvisioners = config.filter_attribute_not_in_list(allProvisioners,
+                     "type", allowed_list, false)
+```
+
+This function is used by several cloud-agnostic policies that allow certain types of items including [allowed-datasources.sentinel](../../../cloud-agnostic/allowed-datasources.sentinel), [allowed-providers.sentinel](../../../cloud-agnostic/allowed-providers.sentinel), [allowed-provisioners.sentinel](../../../cloud-agnostic/allowed-provisioners.sentinel), and [allowed-resources.sentinel](../../../cloud-agnostic/allowed-resources.sentinel).

--- a/common-functions/tfconfig-functions/docs/find_all_datasources.md
+++ b/common-functions/tfconfig-functions/docs/find_all_datasources.md
@@ -1,0 +1,30 @@
+# find_all_datasources
+This function finds all data sources in all modules in the Terraform configuration of the current plan's workspace using the [tfconfig/v2](https://www.terraform.io/docs/cloud/sentinel/import/tfconfig-v2.html) import.
+
+Calling it is equivalent to filtering `tfconfig.resources` to those with `mode` equal to `data`, which indicates that they are data sources rather than managed resources.
+
+## Sentinel Module
+This function is contained in the [tfconfig-functions.sentinel](../../tfconfig-functions.sentinel) module.
+
+## Declaration
+`find_all_datasources = func()`
+
+## Arguments
+None
+
+## Common Functions Used
+None
+
+## What It Returns
+This function returns a single flat map of data sources indexed by the complete [addresses](https://www.terraform.io/docs/internals/resource-addressing.html) of the data sources (excluding indices representing their counts). The map actually contains all data sources from the [`tfconfig.resources`](https://www.terraform.io/docs/cloud/sentinel/import/tfconfig-v2.html#the-resources-collection) collection.
+
+## What It Prints
+This function does not print anything.
+
+## Examples
+Here is an example of calling this function, assuming that the tfconfig-functions.sentinel file that contains it has been imported with the alias `config`:
+```
+allDatasources = config.find_all_datasources()
+```
+
+This function is used by the [prohibited-datasources.sentinel (Cloud Agnostic)](../../../cloud-agnostic/prohibited-datasources.sentinel) and [allowed-datasources.sentinel (Cloud Agnostic)](../../../cloud-agnostic/allowed-datasources.sentinel) policies.

--- a/common-functions/tfconfig-functions/docs/find_all_module_calls.md
+++ b/common-functions/tfconfig-functions/docs/find_all_module_calls.md
@@ -1,0 +1,28 @@
+# find_all_module_calls
+This function finds all module calls in all modules in the Terraform configuration of the current plan's workspace using the [tfconfig/v2](https://www.terraform.io/docs/cloud/sentinel/import/tfconfig-v2.html) import.
+
+Calling it is equivalent to referencing `tfconfig.module_calls`. It is included so that policies that use the tfconfig-functions.sentinel module do not need to import both it and the tfconfig/v2 module.
+
+## Sentinel Module
+This function is contained in the [tfconfig-functions.sentinel](../../tfconfig-functions.sentinel) module.
+
+## Declaration
+`find_all_module_calls = func()`
+
+## Arguments
+None
+
+## Common Functions Used
+None
+
+## What It Returns
+This function returns a single flat map of all module_calls indexed by the address of the module_call's module and its name. The map actually is identical to the [`tfconfig.module_calls`](https://www.terraform.io/docs/cloud/sentinel/import/tfconfig-v2.html#the-module_calls-collection) collection.
+
+## What It Prints
+This function does not print anything.
+
+## Examples
+Here is an example of calling this function, assuming that the tfconfig-functions.sentinel file that contains it has been imported with the alias `config`:
+```
+allModuleCalls = config.find_all_module_calls()
+```

--- a/common-functions/tfconfig-functions/docs/find_all_outputs.md
+++ b/common-functions/tfconfig-functions/docs/find_all_outputs.md
@@ -1,0 +1,28 @@
+# find_all_outputs
+This function finds all outputs in all modules in the Terraform configuration of the current plan's workspace using the [tfconfig/v2](https://www.terraform.io/docs/cloud/sentinel/import/tfconfig-v2.html) import.
+
+Calling it is equivalent to referencing `tfconfig.outputs`. It is included so that policies that use the tfconfig-functions.sentinel module do not need to import both it and the tfconfig/v2 module.
+
+## Sentinel Module
+This function is contained in the [tfconfig-functions.sentinel](../../tfconfig-functions.sentinel) module.
+
+## Declaration
+`find_all_outputs = func()`
+
+## Arguments
+None
+
+## Common Functions Used
+None
+
+## What It Returns
+This function returns a single flat map of all outputs indexed by the address of the output's module and its name. The map actually is identical to the [`tfconfig.outputs`](https://www.terraform.io/docs/cloud/sentinel/import/tfconfig-v2.html#the-outputs-collection) collection.
+
+## What It Prints
+This function does not print anything.
+
+## Examples
+Here is an example of calling this function, assuming that the tfconfig-functions.sentinel file that contains it has been imported with the alias `config`:
+```
+allOutputs = config.find_all_outputs()
+```

--- a/common-functions/tfconfig-functions/docs/find_all_providers.md
+++ b/common-functions/tfconfig-functions/docs/find_all_providers.md
@@ -1,0 +1,30 @@
+# find_all_providers
+This function finds all providers in all modules in the Terraform configuration of the current plan's workspace using the [tfconfig/v2](https://www.terraform.io/docs/cloud/sentinel/import/tfconfig-v2.html) import.
+
+Calling it is equivalent to referencing `tfconfig.providers`. It is included so that policies that use the tfconfig-functions.sentinel module do not need to import both it and the tfconfig/v2 module.
+
+## Sentinel Module
+This function is contained in the [tfconfig-functions.sentinel](../../tfconfig-functions.sentinel) module.
+
+## Declaration
+`find_all_providers = func()`
+
+## Arguments
+None
+
+## Common Functions Used
+None
+
+## What It Returns
+This function returns a single flat map of all providers indexed by the address of the provider's module and the provider's name and alias. The map actually is identical to the [`tfconfig.providers`](https://www.terraform.io/docs/cloud/sentinel/import/tfconfig-v2.html#the-providers-collection) collection.
+
+## What It Prints
+This function does not print anything.
+
+## Examples
+Here is an example of calling this function, assuming that the tfconfig-functions.sentinel file that contains it has been imported with the alias `config`:
+```
+allProviders = config.find_all_providers()
+```
+
+This function is used by the [require-all-providers-have-version-constrain.sentinel (Cloud Agnostic)](../../../cloud-agnostic/require-all-providers-have-version-constrain.sentinel), [prohibited-providers.sentinel (Cloud Agnostic)](../../../cloud-agnostic/prohibited-providers.sentinel) and [allowed-providers.sentinel (Cloud Agnostic)](../../../cloud-agnostic/allowed-providers.sentinel) policies.

--- a/common-functions/tfconfig-functions/docs/find_all_provisioners.md
+++ b/common-functions/tfconfig-functions/docs/find_all_provisioners.md
@@ -1,0 +1,30 @@
+# find_all_provisioners
+This function finds all provisioners in all modules in the Terraform configuration of the current plan's workspace using the [tfconfig/v2](https://www.terraform.io/docs/cloud/sentinel/import/tfconfig-v2.html) import.
+
+Calling it is equivalent to referencing `tfconfig.provisioners`. It is included so that policies that use the tfconfig-functions.sentinel module do not need to import both it and the tfconfig/v2 module.
+
+## Sentinel Module
+This function is contained in the [tfconfig-functions.sentinel](../../tfconfig-functions.sentinel) module.
+
+## Declaration
+`find_all_provisioners = func()`
+
+## Arguments
+None
+
+## Common Functions Used
+None
+
+## What It Returns
+This function returns a single flat map of all provisioners indexed by the address of the resource the provisioner is attached to and the provisioner's own index within that resource's provisioners. The map actually is identical to the [`tfconfig.provisioners`](https://www.terraform.io/docs/cloud/sentinel/import/tfconfig-v2.html#the-provisioners-collection) collection.
+
+## What It Prints
+This function does not print anything.
+
+## Examples
+Here is an example of calling this function, assuming that the tfconfig-functions.sentinel file that contains it has been imported with the alias `config`:
+```
+allProvisioners = config.find_all_provisioners()
+```
+
+This function is used by the [prohibited-provisioners.sentinel (Cloud Agnostic)](../../../cloud-agnostic/prohibited-provisioners.sentinel) and [allowed-provisioners.sentinel (Cloud Agnostic)](../../../cloud-agnostic/allowed-provisioners.sentinel) policies.

--- a/common-functions/tfconfig-functions/docs/find_all_resources.md
+++ b/common-functions/tfconfig-functions/docs/find_all_resources.md
@@ -1,0 +1,30 @@
+# find_all_resources
+This function finds all managed resources in all modules in the Terraform configuration of the current plan's workspace using the [tfconfig/v2](https://www.terraform.io/docs/cloud/sentinel/import/tfconfig-v2.html) import.
+
+Calling it is equivalent to filtering `tfconfig.resources` to those with `mode` equal to `managed`, which indicates that they are managed resources rather than data sources.
+
+## Sentinel Module
+This function is contained in the [tfconfig-functions.sentinel](../../tfconfig-functions.sentinel) module.
+
+## Declaration
+`find_all_resources = func()`
+
+## Arguments
+None
+
+## Common Functions Used
+None
+
+## What It Returns
+This function returns a single flat map of managed resources indexed by the complete [addresses](https://www.terraform.io/docs/internals/resource-addressing.html) of the resources (excluding indices representing their counts). The map actually contains all managed resources from the [`tfconfig.resources`](https://www.terraform.io/docs/cloud/sentinel/import/tfconfig-v2.html#the-resources-collection) collection.
+
+## What It Prints
+This function does not print anything.
+
+## Examples
+Here is an example of calling this function, assuming that the tfconfig-functions.sentinel file that contains it has been imported with the alias `config`:
+```
+allResources = config.find_all_resources()
+```
+
+This function is used by the [prohibited-resources.sentinel (Cloud Agnostic)](../../../cloud-agnostic/prohibited-resources.sentinel) and [allowed-resources.sentinel (Cloud Agnostic)](../../../cloud-agnostic/allowed-resources.sentinel) policies.

--- a/common-functions/tfconfig-functions/docs/find_all_variables.md
+++ b/common-functions/tfconfig-functions/docs/find_all_variables.md
@@ -1,0 +1,28 @@
+# find_all_variables
+This function finds all variables in all modules in the Terraform configuration of the current plan's workspace using the [tfconfig/v2](https://www.terraform.io/docs/cloud/sentinel/import/tfconfig-v2.html) import.
+
+Calling it is equivalent to referencing `tfconfig.variables`. It is included so that policies that use the tfconfig-functions.sentinel module do not need to import both it and the tfconfig/v2 module.
+
+## Sentinel Module
+This function is contained in the [tfconfig-functions.sentinel](../../tfconfig-functions.sentinel) module.
+
+## Declaration
+`find_all_variables = func()`
+
+## Arguments
+None
+
+## Common Functions Used
+None
+
+## What It Returns
+This function returns a single flat map of all variables indexed by the address of the variable's module and its name. The map actually is identical to the [`tfconfig.variables`](https://www.terraform.io/docs/cloud/sentinel/import/tfconfig-v2.html#the-variables-collection) collection.
+
+## What It Prints
+This function does not print anything.
+
+## Examples
+Here is an example of calling this function, assuming that the tfconfig-functions.sentinel file that contains it has been imported with the alias `config`:
+```
+allVariables = config.find_all_variables()
+```

--- a/common-functions/tfconfig-functions/docs/find_datasources_by_provider.md
+++ b/common-functions/tfconfig-functions/docs/find_datasources_by_provider.md
@@ -1,0 +1,32 @@
+# find_datasources_by_provider
+This function finds all data sources created by a specific provider in the Terraform configuration of the current plan's workspace using the [tfconfig/v2](https://www.terraform.io/docs/cloud/sentinel/import/tfconfig-v2.html) import.
+
+## Sentinel Module
+This function is contained in the [tfconfig-functions.sentinel](../../tfconfig-functions.sentinel) module.
+
+## Declaration
+`find_datasources_by_provider = func(provider)`
+
+## Arguments
+* **provider**: the provider of data sources to find, given as a string.
+
+## Common Functions Used
+None
+
+## What It Returns
+This function returns a single flat map of data sources indexed by the complete [addresses](https://www.terraform.io/docs/internals/resource-addressing.html) of the data sources (excluding indices representing their counts). The map is actually a filtered sub-collection of the [`tfconfig.resources`](https://www.terraform.io/docs/cloud/sentinel/import/tfconfig-v2.html#the-resources-collection) collection.
+
+## What It Prints
+This function does not print anything.
+
+## Examples
+Here are some examples of calling this function, assuming that the tfconfig-functions.sentinel file that contains it has been imported with the alias `config`:
+```
+allAWSDatasources = config.find_datasources_by_provider("aws")
+
+allAzureDatasources = config.find_datasources_by_provider("azurerm")
+
+allGoogleDatasources = config.find_datasources_by_provider("google")
+
+allVMwareDatasources = config.find_datasources_by_provider("vsphere")
+```

--- a/common-functions/tfconfig-functions/docs/find_datasources_by_type.md
+++ b/common-functions/tfconfig-functions/docs/find_datasources_by_type.md
@@ -1,0 +1,32 @@
+# find_datasources_by_type
+This function finds all data sources of a specific type in the Terraform configuration of the current plan's workspace using the [tfconfig/v2](https://www.terraform.io/docs/cloud/sentinel/import/tfconfig-v2.html) import.
+
+## Sentinel Module
+This function is contained in the [tfconfig-functions.sentinel](../../tfconfig-functions.sentinel) module.
+
+## Declaration
+`find_datasources_by_type = func(type)`
+
+## Arguments
+* **type**: the type of data source to find, given as a string.
+
+## Common Functions Used
+None
+
+## What It Returns
+This function returns a single flat map of data sources indexed by the complete [addresses](https://www.terraform.io/docs/internals/resource-addressing.html) of the data sources (excluding indices representing their counts). The map is actually a filtered sub-collection of the [`tfconfig.resources`](https://www.terraform.io/docs/cloud/sentinel/import/tfconfig-v2.html#the-resources-collection) collection.
+
+## What It Prints
+This function does not print anything.
+
+## Examples
+Here are some examples of calling this function, assuming that the tfconfig-functions.sentinel file that contains it has been imported with the alias `config`:
+```
+allAMIs = config.find_datasources_by_type("aws_ami")
+
+allImages = config.find_datasources_by_type("azurerm_image")
+
+allImages = config.find_datasources_by_type("google_compute_image")
+
+allDatastores = config.find_datasources_by_type("vsphere_datastore")
+```

--- a/common-functions/tfconfig-functions/docs/find_datasources_in_module.md
+++ b/common-functions/tfconfig-functions/docs/find_datasources_in_module.md
@@ -1,0 +1,28 @@
+# find_datasources_in_module
+This function finds all data sources in a specific module in the Terraform configuration of the current plan's workspace using the [tfconfig/v2](https://www.terraform.io/docs/cloud/sentinel/import/tfconfig-v2.html) import.
+
+## Sentinel Module
+This function is contained in the [tfconfig-functions.sentinel](../../tfconfig-functions.sentinel) module.
+
+## Declaration
+`find_datasources_in_module = func(module_address)`
+
+## Arguments
+* **module_address**: the address of the module containing data sources to find, given as a string. The root module is represented by "". A module named `network` called by the root module is represented by "module.network". if that module contained a module named `subnets`, it would be represented by "module.network.module.subnets".
+
+## Common Functions Used
+None
+
+## What It Returns
+This function returns a single flat map of data sources indexed by the complete [addresses](https://www.terraform.io/docs/internals/resource-addressing.html) of the data sources (excluding indices representing their counts). The map is actually a filtered sub-collection of the [`tfconfig.resources`](https://www.terraform.io/docs/cloud/sentinel/import/tfconfig-v2.html#the-resources-collection) collection.
+
+## What It Prints
+This function does not print anything.
+
+## Examples
+Here are some examples of calling this function, assuming that the tfconfig-functions.sentinel file that contains it has been imported with the alias `config`:
+```
+allRootModuleDatasources = config.find_datasources_in_module("")
+
+allNetworkDatasources = config.find_datasources_in_module("module.network")
+```

--- a/common-functions/tfconfig-functions/docs/find_descendant_modules.md
+++ b/common-functions/tfconfig-functions/docs/find_descendant_modules.md
@@ -1,0 +1,38 @@
+# find_descendant_modules
+This function finds the addresses of all modules called directly or indirectly by a module in the Terraform configuration of the current plan's workspace using the [tfconfig/v2](https://www.terraform.io/docs/cloud/sentinel/import/tfconfig-v2.html) import.
+
+It does this by calling itself recursively.
+
+## Sentinel Module
+This function is contained in the [tfconfig-functions.sentinel](../../tfconfig-functions.sentinel) module.
+
+## Declaration
+`find_descendant_modules = func(module_address)`
+
+## Arguments
+* **module_address**: the address of the module containing descendant modules to find, given as a string. The root module is represented by "". A module with label `network` called by the root module is represented by "module.network". if that module contained a module with label `subnets`, it would be represented by "module.network.module.subnets".
+
+You can determine all module addresses in your current configuration by calling `find_descendant_modules("")`.
+
+## Common Functions Used
+This function calls `find_module_calls_in_module()`.
+
+## What It Returns
+This function returns a list of module addresses called directly or indirectly from the specified module.
+
+## What It Prints
+This function does not print anything.
+
+## Examples
+Here is an example of calling this function, assuming that the tfconfig-functions.sentinel file that contains it has been imported with the alias `config`:
+```
+allModuleAddresses = config.find_descendant_modules("")
+```
+
+This function calls itself recursively with this code:
+```
+module_addresses += find_descendant_modules(new_module_address)
+```
+It does not use `config.` before calling itself since that is not necessary when calling a function from inside the module that contains it.
+
+It is used by the [use-latest-module-versions.sentinel](../../../cloud-agnostic/http-examples/use-latest-module-versions.sentinel) policy.

--- a/common-functions/tfconfig-functions/docs/find_module_calls_in_module.md
+++ b/common-functions/tfconfig-functions/docs/find_module_calls_in_module.md
@@ -1,0 +1,34 @@
+# find_module_calls_in_module
+This function finds all direct module calls in a specific module in the Terraform configuration of the current plan's workspace using the [tfconfig/v2](https://www.terraform.io/docs/cloud/sentinel/import/tfconfig-v2.html) import.
+
+## Sentinel Module
+This function is contained in the [tfconfig-functions.sentinel](../../tfconfig-functions.sentinel) module.
+
+## Declaration
+`find_module_calls_in_module = func(module_address)`
+
+## Arguments
+* **module_address**: the address of the module containing module_calls to find, given as a string. The root module is represented by "". A module named `network` called by the root module is represented by "module.network". if that module contained a module named `subnets`, it would be represented by "module.network.module.subnets".
+
+You can determine all module addresses in your current configuration by calling `find_descendant_modules("")`.
+
+## Common Functions Used
+None
+
+## What It Returns
+This function returns a single flat map of module calls indexed by the address of the module call's parent module and the module call's name. The map is actually a filtered sub-collection of the [`tfconfig.module_calls`](https://www.terraform.io/docs/cloud/sentinel/import/tfconfig-v2.html#the-module_calls-collection) collection.
+
+## What It Prints
+This function does not print anything.
+
+## Examples
+Here are some examples of calling this function, assuming that the tfconfig-functions.sentinel file that contains it has been imported with the alias `config`:
+```
+rootModuleCalls = config.find_module_calls_in_module("")
+
+networkModuleCalls = config.find_module_calls_in_module("module.network")
+```
+
+This function is called by the `find_descendant_modules` function of the tfconfig-functions.sentinel module.
+
+It is also called by the [use-lastest-module-versions.sentinel](../../../cloud-agnostic/http-examples/use-lastest-module-versions.sentinel) policy.

--- a/common-functions/tfconfig-functions/docs/find_outputs_by_sensitivity.md
+++ b/common-functions/tfconfig-functions/docs/find_outputs_by_sensitivity.md
@@ -1,0 +1,28 @@
+# find_outputs_by_sensitivity
+This function finds all outputs of a specific sensitivity (`true` or `false`) in the Terraform configuration of the current plan's workspace using the [tfconfig/v2](https://www.terraform.io/docs/cloud/sentinel/import/tfconfig-v2.html) import.
+
+## Sentinel Module
+This function is contained in the [tfconfig-functions.sentinel](../../tfconfig-functions.sentinel) module.
+
+## Declaration
+`find_outputs_by_sensitivity = func(sensitive)`
+
+## Arguments
+* **sensitive**: the desired sensitivity of outputs which can be `true` or `false` (without quotes).
+
+## Common Functions Used
+None
+
+## What It Returns
+This function returns a single flat map of outputs indexed by the address of the module and the name of the output. The map is actually a filtered sub-collection of the [`tfconfig.outputs`](https://www.terraform.io/docs/cloud/sentinel/import/tfconfig-v2.html#the-outputs-collection) collection.
+
+## What It Prints
+This function does not print anything.
+
+## Examples
+Here are some examples of calling this function, assuming that the tfconfig-functions.sentinel file that contains it has been imported with the alias `config`:
+```
+sensitiveOutputs = config.find_outputs_by_sensitivity(true)
+
+nonSensitiveOutputs = config.find_outputs_by_sensitivity(false)
+```

--- a/common-functions/tfconfig-functions/docs/find_outputs_in_module.md
+++ b/common-functions/tfconfig-functions/docs/find_outputs_in_module.md
@@ -1,0 +1,28 @@
+# find_outputs_in_module
+This function finds all outputs in a specific module in the Terraform configuration of the current plan's workspace using the [tfconfig/v2](https://www.terraform.io/docs/cloud/sentinel/import/tfconfig-v2.html) import.
+
+## Sentinel Module
+This function is contained in the [tfconfig-functions.sentinel](../../tfconfig-functions.sentinel) module.
+
+## Declaration
+`find_outputs_in_module = func(module_address)`
+
+## Arguments
+* **module_address**: the address of the module containing outputs to find, given as a string. The root module is represented by "". A module named `network` called by the root module is represented by "module.network". if that module contained a module named `subnets`, it would be represented by "module.network.module.subnets".
+
+## Common Functions Used
+None
+
+## What It Returns
+This function returns a single flat map of outputs indexed by the address of the module and the name of the output. The map is actually a filtered sub-collection of the [`tfconfig.outputs`](https://www.terraform.io/docs/cloud/sentinel/import/tfconfig-v2.html#the-outputs-collection) collection.
+
+## What It Prints
+This function does not print anything.
+
+## Examples
+Here are some examples of calling this function, assuming that the tfconfig-functions.sentinel file that contains it has been imported with the alias `config`:
+```
+allRootModuleOutputs = config.find_outputs_in_module("")
+
+allNetworkOutputs = config.find_outputs_in_module("module.network")
+```

--- a/common-functions/tfconfig-functions/docs/find_providers_by_type.md
+++ b/common-functions/tfconfig-functions/docs/find_providers_by_type.md
@@ -1,0 +1,34 @@
+# find_providers_by_type
+This function finds all providers of a specific type in the Terraform configuration of the current plan's workspace using the [tfconfig/v2](https://www.terraform.io/docs/cloud/sentinel/import/tfconfig-v2.html) import.
+
+## Sentinel Module
+This function is contained in the [tfconfig-functions.sentinel](../../tfconfig-functions.sentinel) module.
+
+## Declaration
+`find_providers_by_type = func(type)`
+
+## Arguments
+* **type**: the type of provider to find, given as a string.
+
+## Common Functions Used
+None
+
+## What It Returns
+This function returns a single flat map of providers indexed by the address of the provider's module and the provider's name and alias. The map is actually a filtered sub-collection of the [`tfconfig.providers`](https://www.terraform.io/docs/cloud/sentinel/import/tfconfig-v2.html#the-providers-collection) collection.
+
+## What It Prints
+This function does not print anything.
+
+## Examples
+Here are some examples of calling this function, assuming that the tfconfig-functions.sentinel file that contains it has been imported with the alias `config`:
+```
+awsProviders = config.find_providers_by_type("aws")
+
+azureProviders = config.find_providers_by_type("azurerm")
+
+googleProviders = config.find_providers_by_type("google")
+
+vmwareProviders = config.find_providers_by_type("vsphere")
+```
+
+This function is used by the function `get_assumed_roles` in the  [aws-functions](../../../aws/aws-functions/aws-functions.sentinel) module.

--- a/common-functions/tfconfig-functions/docs/find_providers_in_module.md
+++ b/common-functions/tfconfig-functions/docs/find_providers_in_module.md
@@ -1,0 +1,28 @@
+# find_providers_in_module
+This function finds all providers in a specific module in the Terraform configuration of the current plan's workspace using the [tfconfig/v2](https://www.terraform.io/docs/cloud/sentinel/import/tfconfig-v2.html) import.
+
+## Sentinel Module
+This function is contained in the [tfconfig-functions.sentinel](../../tfconfig-functions.sentinel) module.
+
+## Declaration
+`find_providers_in_module = func(module_address)`
+
+## Arguments
+* **module_address**: the address of the module containing providers to find, given as a string. The root module is represented by "". A module named `network` called by the root module is represented by "module.network". if that module contained a module named `subnets`, it would be represented by "module.network.module.subnets".
+
+## Common Functions Used
+None
+
+## What It Returns
+This function returns a single flat map of providers indexed by the address of the provider's module and the provider's name and alias. The map is actually a filtered sub-collection of the [`tfconfig.providers`](https://www.terraform.io/docs/cloud/sentinel/import/tfconfig-v2.html#the-providers-collection) collection.
+
+## What It Prints
+This function does not print anything.
+
+## Examples
+Here are some examples of calling this function, assuming that the tfconfig-functions.sentinel file that contains it has been imported with the alias `config`:
+```
+allRootModuleProviders = config.find_providers_in_module("")
+
+allNetworkProviders = config.find_providers_in_module("module.network")
+```

--- a/common-functions/tfconfig-functions/docs/find_provisioners_by_type.md
+++ b/common-functions/tfconfig-functions/docs/find_provisioners_by_type.md
@@ -1,0 +1,30 @@
+# find_provisioners_by_type
+This function finds all provisioners of a specific type in the Terraform configuration of the current plan's workspace using the [tfconfig/v2](https://www.terraform.io/docs/cloud/sentinel/import/tfconfig-v2.html) import.
+
+## Sentinel Module
+This function is contained in the [tfconfig-functions.sentinel](../../tfconfig-functions.sentinel) module.
+
+## Declaration
+`find_provisioners_by_type = func(type)`
+
+## Arguments
+* **type**: the type of provisioner to find, given as a string.
+
+## Common Functions Used
+None
+
+## What It Returns
+This function returns a single flat map of provisioners indexed by the address of the resource the provisioner is attached to and the provisioner's own index within that resource's provisioners. The map is actually a filtered sub-collection of the [`tfconfig.provisioners`](https://www.terraform.io/docs/cloud/sentinel/import/tfconfig-v2.html#the-provisioners-collection) collection.
+
+## What It Prints
+This function does not print anything.
+
+## Examples
+Here are some examples of calling this function, assuming that the tfconfig-functions.sentinel file that contains it has been imported with the alias `config`:
+```
+remoteExecProvisioners = config.find_provisioners_by_type("remote-exec")
+
+localExecProvisioners = config.find_provisioners_by_type("local-exec")
+```
+
+This function is used by the cloud-agnostic [prevent-remote-exec-provisioners-on-null-resources.sentinel](../../../cloud-agnostic/prevent-remote-exec-provisioners-on-null-resources.sentinel) policy.

--- a/common-functions/tfconfig-functions/docs/find_resources_by_provider.md
+++ b/common-functions/tfconfig-functions/docs/find_resources_by_provider.md
@@ -1,0 +1,32 @@
+# find_resources_by_provider
+This function finds all managed resources created by a specific provider in the Terraform configuration of the current plan's workspace using the [tfconfig/v2](https://www.terraform.io/docs/cloud/sentinel/import/tfconfig-v2.html) import.
+
+## Sentinel Module
+This function is contained in the [tfconfig-functions.sentinel](../../tfconfig-functions.sentinel) module.
+
+## Declaration
+`find_resources_by_provider = func(provider)`
+
+## Arguments
+* **provider**: the provider of resources to find, given as a string.
+
+## Common Functions Used
+None
+
+## What It Returns
+This function returns a single flat map of resources indexed by the complete [addresses](https://www.terraform.io/docs/internals/resource-addressing.html) of the resources (excluding indices representing their counts). The map is actually a filtered sub-collection of the [`tfconfig.resources`](https://www.terraform.io/docs/cloud/sentinel/import/tfconfig-v2.html#the-resources-collection) collection.
+
+## What It Prints
+This function does not print anything.
+
+## Examples
+Here are some examples of calling this function, assuming that the tfconfig-functions.sentinel file that contains it has been imported with the alias `config`:
+```
+allAWSResources = config.find_resources_by_provider("aws")
+
+allAzureResources = config.find_resources_by_provider("azurerm")
+
+allGoogleResources = config.find_resources_by_provider("google")
+
+allVMwareResources = config.find_resources_by_provider("vsphere")
+```

--- a/common-functions/tfconfig-functions/docs/find_resources_by_type.md
+++ b/common-functions/tfconfig-functions/docs/find_resources_by_type.md
@@ -1,0 +1,32 @@
+# find_resources_by_type
+This function finds all managed resources of a specific type in the Terraform configuration of the current plan's workspace using the [tfconfig/v2](https://www.terraform.io/docs/cloud/sentinel/import/tfconfig-v2.html) import.
+
+## Sentinel Module
+This function is contained in the [tfconfig-functions.sentinel](../../tfconfig-functions.sentinel) module.
+
+## Declaration
+`find_resources_by_type = func(type)`
+
+## Arguments
+* **type**: the type of resource to find, given as a string.
+
+## Common Functions Used
+None
+
+## What It Returns
+This function returns a single flat map of resources indexed by the complete [addresses](https://www.terraform.io/docs/internals/resource-addressing.html) of the resources (excluding indices representing their counts). The map is actually a filtered sub-collection of the [`tfconfig.resources`](https://www.terraform.io/docs/cloud/sentinel/import/tfconfig-v2.html#the-resources-collection) collection.
+
+## What It Prints
+This function does not print anything.
+
+## Examples
+Here are some examples of calling this function, assuming that the tfconfig-functions.sentinel file that contains it has been imported with the alias `config`:
+```
+allEC2Instances = config.find_resources_by_type("aws_instance")
+
+allAzureVMs = config.find_resources_by_type("azurerm_virtual_machine")
+
+allGCEInstances = config.find_resources_by_type("google_compute_instance")
+
+allVMs = config.find_resources_by_type("vsphere_virtual_machine")
+```

--- a/common-functions/tfconfig-functions/docs/find_resources_in_module.md
+++ b/common-functions/tfconfig-functions/docs/find_resources_in_module.md
@@ -1,0 +1,28 @@
+# find_resources_in_module
+This function finds all managed resources in a specific module in the Terraform configuration of the current plan's workspace using the [tfconfig/v2](https://www.terraform.io/docs/cloud/sentinel/import/tfconfig-v2.html) import.
+
+## Sentinel Module
+This function is contained in the [tfconfig-functions.sentinel](../../tfconfig-functions.sentinel) module.
+
+## Declaration
+`find_resources_in_module = func(module_address)`
+
+## Arguments
+* **module_address**: the address of the module containing resources to find, given as a string. The root module is represented by "". A module named `network` called by the root module is represented by "module.network". if that module contained a module named `subnets`, it would be represented by "module.network.module.subnets".
+
+## Common Functions Used
+None
+
+## What It Returns
+This function returns a single flat map of resources indexed by the complete [addresses](https://www.terraform.io/docs/internals/resource-addressing.html) of the resources (excluding indices representing their counts). The map is actually a filtered sub-collection of the [`tfconfig.resources`](https://www.terraform.io/docs/cloud/sentinel/import/tfconfig-v2.html#the-resources-collection) collection.
+
+## What It Prints
+This function does not print anything.
+
+## Examples
+Here are some examples of calling this function, assuming that the tfconfig-functions.sentinel file that contains it has been imported with the alias `config`:
+```
+allRootModuleResources = config.find_resources_in_module("")
+
+allNetworkResources = config.find_resources_in_module("module.network")
+```

--- a/common-functions/tfconfig-functions/docs/find_variables_in_module.md
+++ b/common-functions/tfconfig-functions/docs/find_variables_in_module.md
@@ -1,0 +1,28 @@
+# find_variables_in_module
+This function finds all variables in a specific module in the Terraform configuration of the current plan's workspace using the [tfconfig/v2](https://www.terraform.io/docs/cloud/sentinel/import/tfconfig-v2.html) import.
+
+## Sentinel Module
+This function is contained in the [tfconfig-functions.sentinel](../../tfconfig-functions.sentinel) module.
+
+## Declaration
+`find_variables_in_module = func(module_address)`
+
+## Arguments
+* **module_address**: the address of the module containing variables to find, given as a string. The root module is represented by "". A module named `network` called by the root module is represented by "module.network". if that module contained a module named `subnets`, it would be represented by "module.network.module.subnets".
+
+## Common Functions Used
+None
+
+## What It Returns
+This function returns a single flat map of variables indexed by the address of the module and the name of the variable. The map is actually a filtered sub-collection of the [`tfconfig.variables`](https://www.terraform.io/docs/cloud/sentinel/import/tfconfig-v2.html#the-variables-collection) collection.
+
+## What It Prints
+This function does not print anything.
+
+## Examples
+Here are some examples of calling this function, assuming that the tfconfig-functions.sentinel file that contains it has been imported with the alias `config`:
+```
+allRootModuleVariables = config.find_variables_in_module("")
+
+allNetworkVariables = config.find_variables_in_module("module.network")
+```

--- a/common-functions/tfconfig-functions/docs/get_ancestor_module_source.md
+++ b/common-functions/tfconfig-functions/docs/get_ancestor_module_source.md
@@ -1,0 +1,33 @@
+# get_ancestor_module_source
+This function finds the source of the first ancestor module that is not a local module of the module containing an item from its `module_address` using the [tfconfig/v2](https://www.terraform.io/docs/cloud/sentinel/import/tfconfig-v2.html) import. (A local module is indicated by use of a source starting with "./" or "../".)
+
+It does this by parsing `module_address` which will look like "module.A.module.B" if the item is not in the root module or "" if it is in the root module. It then finds the `module_call` in the parent module that calls the original module and then gets `source` from that module call.
+
+However, if the `source` starts with "./" or "../", the function then calls itself recursively against the address of the module's parent module. It keeps doing this until it finds a non-local module and then gives that module's source.
+
+## Sentinel Module
+This function is contained in the [tfconfig-functions.sentinel](../../tfconfig-functions.sentinel) module.
+
+## Declaration
+`get_ancestor_module_source = func(module_address)`
+
+## Arguments
+* **module_address**: the address of the module containing some item, given as a string. The root module is represented by "". A module with label `network` called by the root module is represented by "module.network". if that module contained a module with label `subnets`, it would be represented by "module.network.module.subnets".
+
+## Common Functions Used
+None.
+
+## What It Returns
+This function returns a string containing the source of the ancestor module represented by the `module_address` parameter. If called against the root module of a Terraform configuration, it returns "root".
+
+## What It Prints
+This function does not print anything.
+
+## Examples
+Here is an example of calling this function, assuming that the tfconfig-functions.sentinel file that contains it has been imported with the alias `config`:
+```
+module_address = r.module_address
+module_source = config.get_ancestor_module_source(module_address)
+```
+
+It is used by the [restrict-resources-by-module-source.sentinel](../../../cloud-agnostic/restrict-resources-by-module-source.sentinel) policy.

--- a/common-functions/tfconfig-functions/docs/get_module_source.md
+++ b/common-functions/tfconfig-functions/docs/get_module_source.md
@@ -1,0 +1,29 @@
+# get_module_source
+This function finds the source of the module containing an item from its `module_address` using the [tfconfig/v2](https://www.terraform.io/docs/cloud/sentinel/import/tfconfig-v2.html) import.
+
+It does this by parsing `module_address` which will look like "module.A.module.B" if the item is not in the root module or "" if it is in the root module. It then finds the `module_call` in the parent module that calls the original module and then gets `source` from that module call.
+
+## Sentinel Module
+This function is contained in the [tfconfig-functions.sentinel](../../tfconfig-functions.sentinel) module.
+
+## Declaration
+`get_module_source = func(module_address)`
+
+## Arguments
+* **module_address**: the address of the module containing some item, given as a string. The root module is represented by "". A module with label `network` called by the root module is represented by "module.network". if that module contained a module with label `subnets`, it would be represented by "module.network.module.subnets".
+
+## Common Functions Used
+None.
+
+## What It Returns
+This function returns a string containing the source of the module represented by the `module_address` parameter. If called against the root module of a Terraform configuration, it returns "root".
+
+## What It Prints
+This function does not print anything.
+
+## Examples
+Here is an example of calling this function, assuming that the tfconfig-functions.sentinel file that contains it has been imported with the alias `config`:
+```
+module_address = r.module_address
+module_source = config.get_module_source(module_address)
+```

--- a/common-functions/tfconfig-functions/docs/get_parent_module_address.md
+++ b/common-functions/tfconfig-functions/docs/get_parent_module_address.md
@@ -1,0 +1,29 @@
+# get_parent_module_address
+This function finds the address of the parent module of the module containing an item from its `module_address` using the [tfconfig/v2](https://www.terraform.io/docs/cloud/sentinel/import/tfconfig-v2.html) import.
+
+It does this by parsing `module_address` which will look like "module.A.module.B" if the item is not in the root module or "" if it is in the root module.
+
+## Sentinel Module
+This function is contained in the [tfconfig-functions.sentinel](../../tfconfig-functions.sentinel) module.
+
+## Declaration
+`get_parent_module_address = func(module_address)`
+
+## Arguments
+* **module_address**: the address of the module containing some item, given as a string. The root module is represented by "". A module with label `network` called by the root module is represented by "module.network". if that module contained a module with label `subnets`, it would be represented by "module.network.module.subnets".
+
+## Common Functions Used
+None.
+
+## What It Returns
+This function returns a string containing the address of the parent module of the module represented by the `module_address` parameter. If called against the root module of a Terraform configuration, it returns "root".
+
+## What It Prints
+This function does not print anything.
+
+## Examples
+Here is an example of calling this function, assuming that the tfconfig-functions.sentinel file that contains it has been imported with the alias `config`:
+```
+module_address = r.module_address
+parent_module_address = config.get_parent_module_address(module_address)
+```

--- a/common-functions/tfconfig-functions/docs/print_violations.md
+++ b/common-functions/tfconfig-functions/docs/print_violations.md
@@ -1,0 +1,31 @@
+# print_violations
+This function prints the violation messages that were previously returned by one of the filter functions of the tfconfig-functions.sentinel module. While those filter functions can print the violations messages themselves (if their `prtmsg` parameter is set to `true`), it is sometimes preferable to delay printing of the messages until later in the policy, typically after printing one or more messages giving the address of the resource that violated it.
+
+## Sentinel Module
+This function is contained in the [tfconfig-functions.sentinel](../../tfconfig-functions.sentinel) module.
+
+## Declaration
+`print_violations = func(messages, prefix)`
+
+## Arguments
+* **messages**: a map of messages returned by one of the filter functions.
+* **prefix**: a string that should be printed before each message.
+
+## Common Functions Used
+None
+
+## What It Returns
+This function always returns `true`.
+
+## What It Prints
+This function prints the messages in the `messages` map prefixed with the `prefix` string.
+
+## Examples
+Here are some examples of calling this function, assuming that the tfconfig-functions.sentinel file that contains it has been imported with the alias `config`:
+```
+config.print_violations(violatingDatasources["messages"], "Blacklisted data source:")
+
+config.print_violations(violatingProviders["messages"], "Blacklisted provider:")
+```
+
+This function is used by many of the cloud agnostic policies including [prohibited-datasources.sentinel](../../../cloud-agnostic/prohibited-datasources.sentinel) and [prohibited-providers.sentinel](../../../cloud-agnostic/prohibited-providers.sentinel).

--- a/common-functions/tfconfig-functions/docs/to_string.md
+++ b/common-functions/tfconfig-functions/docs/to_string.md
@@ -1,0 +1,28 @@
+# to_string
+This function converts any Sentinel object including complex compositions of primitive types (string, int, float, and bool), null, undefined, lists, and maps to a string.
+
+## Sentinel Module
+This function is contained in the [tfconfig-functions.sentinel](../../tfconfig-functions.sentinel) module.
+
+## Declaration
+`to_string = func(obj)`
+
+## Arguments
+* **obj**: a Sentinel object of any type
+
+## Common Functions Used
+This function calls itself recursively to support composite objects.
+
+## What It Returns
+This function returns a single string.
+
+## What It Prints
+This function does not print anything.
+
+## Examples
+This function is called by all of the filter functions in the tfconfig-functions.sentinel module. Here is a typical example:
+```
+message = to_string(index) + " has " + to_string(attr) + " with value " +
+          to_string(val) + " that is not in the allowed list: " +
+          to_string(allowed)
+```

--- a/common-functions/tfconfig-functions/tfconfig-functions.sentinel
+++ b/common-functions/tfconfig-functions/tfconfig-functions.sentinel
@@ -1,0 +1,659 @@
+# Common functions that use the tfconfig/v2 import
+
+##### Imports #####
+import "tfconfig/v2" as tfconfig
+import "strings"
+import "types"
+
+##### Functions #####
+
+### find_all_resources ###
+# Find all resources of all types using the tfconfig/v2 import.
+find_all_resources = func() {
+	resources = filter tfconfig.resources as address, r {
+		r.mode is "managed"
+	}
+
+	return resources
+}
+
+### find_resources_by_type ###
+# Find all resources of a specific type using the tfconfig/v2 import.
+# The parameter, type, should be a string like "aws_instance".
+find_resources_by_type = func(type) {
+	resources = filter tfconfig.resources as address, r {
+		r.type is type and
+			r.mode is "managed"
+	}
+
+	return resources
+}
+
+### find_resources_in_module ###
+# Find all resources from a specific module using the tfconfig/v2 import.
+find_resources_in_module = func(module_address) {
+	resources = filter tfconfig.resources as address, r {
+		r.module_address is module_address and
+			r.mode is "managed"
+	}
+
+	return resources
+}
+
+### find_resources_by_provider ###
+# Find all resources from a specific provider using the tfconfig/v2 import.
+# The parameter, provider, should be given as a string such as "aws".
+find_resources_by_provider = func(provider) {
+	resources = filter tfconfig.resources as address, r {
+		r.provider_config_key matches "(.*:)?" + provider + "(\\..*)?" and
+			r.mode is "managed"
+	}
+
+	return resources
+}
+
+### find_all_datasources ###
+# Find all data sources of all types using the tfconfig/v2 import.
+find_all_datasources = func() {
+	datasources = filter tfconfig.resources as address, d {
+		d.mode is "data"
+	}
+
+	return datasources
+}
+
+### find_datasources_by_type ###
+# Find all data sources of a specific type using the tfconfig/v2 import.
+# The parameter, type, should be a string like "aws_ami".
+find_datasources_by_type = func(type) {
+	datasources = filter tfconfig.resources as address, d {
+		d.type is type and
+			d.mode is "data"
+	}
+
+	return datasources
+}
+
+### find_datasources_in_module ###
+# Find all data sources from a specific module using the tfconfig/v2 import.
+find_datasources_in_module = func(module_address) {
+	datasources = filter tfconfig.resources as address, d {
+		d.module_address is module_address and
+			d.mode is "data"
+	}
+
+	return datasources
+}
+
+### find_datasources_by_provider ###
+# Find all data sources from a specific provider using the tfconfig/v2 import.
+# The parameter, provider, should be given as a string such as "aws".
+find_datasources_by_provider = func(provider) {
+	datasources = filter tfconfig.resources as address, d {
+		d.provider_config_key matches "(.*:)?" + provider + "(\\..*)?" and
+			d.mode is "data"
+	}
+
+	return datasources
+}
+
+### find_all_provisioners ###
+# Find all provisioners using the tfconfig/v2 import.
+find_all_provisioners = func() {
+	return tfconfig.provisioners
+}
+
+### find_provisioners_by_type ###
+# Find all provisioners of a specific type using the tfconfig/v2 import.
+# The parameter, type, should be a string like "local_exec".
+find_provisioners_by_type = func(type) {
+	provisioners = filter tfconfig.provisioners as address, p {
+		p.type is type
+	}
+
+	return provisioners
+}
+
+### find_all_providers ###
+# Find all providers using the tfconfig/v2 import.
+find_all_providers = func() {
+	return tfconfig.providers
+}
+
+### find_providers_by_type ###
+# Find all providers of a specific type using the tfconfig/v2 import.
+# The parameter, provider, should be given as a string such as "aws".
+find_providers_by_type = func(type) {
+	providers = filter tfconfig.providers as address, p {
+		p.provider_config_key matches "(.*:)?" + type + "(\\..*)?"
+	}
+
+	return providers
+}
+
+### find_providers_in_module ###
+# Find all providers from a specific module using the tfconfig/v2 import.
+find_providers_in_module = func(module_address) {
+	providers = filter tfconfig.providers as address, p {
+		p.module_address is module_address
+	}
+
+	return providers
+}
+
+### find_all_variables ###
+# Find all variables using the tfconfig/v2 import.
+find_all_variables = func() {
+	return tfconfig.variables
+}
+
+### find_variables_in_module ###
+# Find all variables from a specific module using the tfconfig/v2 import.
+find_variables_in_module = func(module_address) {
+	variables = filter tfconfig.variables as address, v {
+		v.module_address is module_address
+	}
+
+	return variables
+}
+
+### find_all_outputs ###
+# Find all outputs using the tfconfig/v2 import.
+find_all_outputs = func() {
+	return tfconfig.outputs
+}
+
+### find_outputs_in_module ###
+# Find all providers from a specific module using the tfconfig/v2 import.
+find_outputs_in_module = func(module_address) {
+	outputs = filter tfconfig.outputs as address, o {
+		o.module_address is module_address
+	}
+
+	return outputs
+}
+
+### find_outputs_by_sensitivity ###
+# Find all providers of specific sensitivity using the tfconfig/v2 import.
+# The parameter, sensitive, should be true or false (without quotes)
+find_outputs_by_sensitivity = func(sensitive) {
+	outputs = filter tfconfig.outputs as address, o {
+		o.sensitive is sensitive
+	}
+
+	return outputs
+}
+
+### find_all_module_calls ###
+# Find all module calls using the tfconfig/v2 import.
+find_all_module_calls = func() {
+	return tfconfig.module_calls
+}
+
+### find_module_calls_in_module ###
+# Find all direct module calls made from a specific module
+# using the tfconfig/v2 import.
+# The parameter, module_address, should be "" for the root module,
+# "module.A" for a module A called by the root module,
+# "module.A.module.B" for module B called by module A called by the root module,
+# and so on.
+find_module_calls_in_module = func(module_address) {
+	module_calls = filter tfconfig.module_calls as address, mc {
+		mc.module_address is module_address
+	}
+
+	return module_calls
+}
+
+### find_descendant_modules ###
+# Find addresses of all modules called directly or indirectly by a module.
+# The provided module address is included.
+# To find all module addresses, call find_descendant_modules("")
+# After calling this function against "", you can call find_module_calls_in_module
+# against any item in the list that is returned.
+find_descendant_modules = func(module_address) {
+	module_addresses = [module_address]
+	mcs = find_module_calls_in_module(module_address)
+	if length(mcs) > 0 {
+		for mcs as ma, mc {
+			if mc.module_address is "" {
+				new_module_address = "module." + mc.name
+			} else {
+				new_module_address = mc.module_address + ".module." + mc.name
+			}
+			module_addresses += find_descendant_modules(new_module_address)
+		}
+	}
+	return module_addresses
+}
+
+### print_violations ###
+# Prints violations returned by any of the filter functions defined below.
+# This would normally only be called if the filter function had been called
+# with prtmsg set to false, which is sometimes done when processing resources
+# and their blocks.
+# If the result of a filter function is assigned to a map like violatingIRs,
+# then you should pass violatingIRs["message"] as the first argument.
+# The prefix argument is printed before the message of each resource.
+print_violations = func(messages, prefix) {
+	for messages as address, message {
+		print(prefix, message)
+	}
+	return true
+}
+
+### to_string ###
+# Convert objects of unknown type to string
+# It is used to build messages added to the messages map returned by the
+# filter functions
+to_string = func(obj) {
+	case types.type_of(obj) {
+		when "string":
+			return obj
+		when "int", "float", "bool":
+			return string(obj)
+		when "null":
+			return "null"
+		when "undefined":
+			return "undefined"
+		when "list":
+			output = "["
+			lastIndex = length(obj) - 1
+			for obj as index, value {
+				if index < lastIndex {
+					output += to_string(value) + ", "
+				} else {
+					output += to_string(value)
+				}
+			}
+			output += "]"
+			return output
+		when "map":
+			output = "{"
+			theKeys = keys(obj)
+			lastIndex = length(theKeys) - 1
+			for theKeys as index, key {
+				if index < lastIndex {
+					output += to_string(key) + ": " + to_string(obj[key]) + ", "
+				} else {
+					output += to_string(key) + ": " + to_string(obj[key])
+				}
+			}
+			output += "}"
+			return output
+		else:
+			return ""
+	}
+}
+
+### evaluate_attribute ###
+# Evaluates an attribute
+# In general, the attribute should be a top-level attribute of item, but
+# we do special processing for attributes with form "config.x"
+# `item` is the item with the attribute
+# `attribute` is the attribute
+evaluate_attribute = func(item, attribute) {
+	# Split the attribute into a list, using "." as the separator
+	attributes = strings.split(attribute, ".")
+	if length(attributes) > 2 {
+		print("An attribute passed to evaluate_attribute can only have 1 or 2 fields")
+		return null
+	}
+	if attributes[0] is "config" {
+		config = item.config[attributes[1]] else {}
+		if "constant_value" in config {
+			# Found constant_value in config
+			return config.constant_value
+		} else if "references" in config {
+			# Found references in config
+			return config.references
+		} else {
+			# Did not find constant_value or references in config
+			return null
+		}
+	} else {
+		# Return the original attribute or the item
+		return item[attribute]
+	}
+}
+
+### filter_attribute_not_in_list ###
+# Filter a list of items such as providers to those with a specified
+# attribute (attr) that is not in a given list of allowed values (allowed).
+# The parameter, attr, can only be a top-level attribute of the collection, items.
+# Set prtmsg to `true` (without quotes) if you want to print violation messages.
+# If you want to disallow null, include "null" in the list (forbidden).
+filter_attribute_not_in_list = func(items, attr, allowed, prtmsg) {
+	violators = {}
+	messages = {}
+
+	# Iterate over items
+	for items as index, item {
+		val = evaluate_attribute(item, attr) else null
+		# Check if the value is null
+		if val is null {
+			val = "null"
+		}
+		# Process lists and maps
+		if types.type_of(val) in ["list", "map"] {
+			message = ""
+			# Check each item of list or map
+			for val as i, v {
+				if v not in allowed {
+					# Add the item and a warning message to the violators list
+					message = to_string(index) + " has " + to_string(attr) + " with value " +
+						to_string(v) +
+						" that is not in the allowed list: " +
+						to_string(allowed)
+				}
+				if message is not "" {
+					# Add the item and warning message to the violators list
+					violators[index] = item
+					messages[index] = message
+					if prtmsg {
+						print(message)
+					}
+				} // end message not ""
+			} // end for
+		} else {
+			# Process single item
+			if val not in allowed {
+				# Add the item and a warning message to the violators list
+				message = to_string(index) + " has " + to_string(attr) +
+					" with value " +
+					to_string(val) +
+					" that is not in the allowed list: " +
+					to_string(allowed)
+				violators[index] = item
+				messages[index] = message
+				if prtmsg {
+					print(message)
+				}
+			} // end if single item not matches
+		} // end single item
+	} // end for items
+	return {"items": violators, "messages": messages}
+}
+
+### filter_attribute_in_list ###
+# Filter a list of items such as providers to those with a specified
+# attribute (attr) that is in a given list of forbidden values (forbidden).
+# The parameter, attr, can only be a top-level attribute of the collection, items.
+# Set prtmsg to `true` (without quotes) if you want to print violation messages.
+# If you want to disallow null, include "null" in the list (forbidden).
+filter_attribute_in_list = func(items, attr, forbidden, prtmsg) {
+	violators = {}
+	messages = {}
+
+	# Iterate over items
+	for items as index, item {
+		val = evaluate_attribute(item, attr) else null
+		# Check if the value is null
+		if val is null {
+			val = "null"
+		}
+		# Process lists and maps
+		if types.type_of(val) in ["list", "map"] {
+			message = ""
+			# Check each item of list or map
+			for val as i, v {
+				if v in forbidden {
+					# Add the item and a warning message to the violators list
+					message = to_string(index) + " has " + to_string(attr) + " with value " +
+						to_string(v) +
+						" that is in the forbidden list: " +
+						to_string(forbidden)
+				}
+				if message is not "" {
+					# Add the item and warning message to the violators list
+					violators[index] = item
+					messages[index] = message
+					if prtmsg {
+						print(message)
+					}
+				} // end message not ""
+			} // end for
+		} else {
+			# Process single item
+			if val in forbidden {
+				# Add the item and a warning message to the violators list
+				message = to_string(index) + " has " + to_string(attr) +
+					" with value " +
+					to_string(val) +
+					" that is in the forbidden list: " +
+					to_string(forbidden)
+				violators[index] = item
+				messages[index] = message
+				if prtmsg {
+					print(message)
+				}
+			} // end if single item not matches
+		} // end single item
+	} // end for items
+
+	return {"items": violators, "messages": messages}
+}
+
+### filter_attribute_does_not_match_regex ###
+# Filter a list of items such as resources to those with a specified
+# attribute (attr) that does not match a regular expression (expr).
+# The parameter, attr, can only be a top-level attribute of items or
+# an attribute in the form "config.x".
+# Set prtmsg to `true` (without quotes) if you want to print violation messages.
+filter_attribute_does_not_match_regex = func(items, attr, expr, prtmsg) {
+	violators = {}
+	messages = {}
+	for items as index, item {
+		val = evaluate_attribute(item, attr) else null
+		if val is null {
+			# Add the item and a warning message to the violators list
+			message = to_string(index) + " has " + to_string(attr) +
+				" that is null or undefined. " +
+				"It is supposed to " +
+				"match the regex " +
+				to_string(expr)
+			violators[index] = item
+			messages[index] = message
+			if prtmsg {
+				print(message)
+			}
+		} else {
+			# Process lists and maps
+			if types.type_of(val) in ["list", "map"] {
+				message = ""
+				# Check each item of list or map
+				for val as i, v {
+					if v not matches expr {
+						# Add to the warning message
+						message += to_string(index) + " has " + to_string(attr) +
+							" with value " +
+							to_string(v) +
+							" that does not match the regex " +
+							to_string(expr) +
+							"\n"
+					}
+					if message is not "" {
+						# Add the item and warning message to the violators list
+						violators[index] = item
+						messages[index] = message
+						if prtmsg {
+							print(message)
+						}
+					} // end message not ""
+				} // end for
+			} else {
+				# Process single item
+				if val not matches expr {
+					# Add the item and a warning message to the violators list
+					message = to_string(index) + " has " + to_string(attr) +
+						" with value " +
+						to_string(val) +
+						" that does not match the regex " +
+						to_string(expr)
+					violators[index] = item
+					messages[index] = message
+					if prtmsg {
+						print(message)
+					}
+				} // end if single item not matches
+			} // end single item
+		} // end not null
+	} // end for items
+	return {"items": violators, "messages": messages}
+}
+
+### filter_attribute_matches_regex ###
+# Filter a list of items such as resources to those with a specified
+# attribute (attr) that matches a regular expression (expr).
+# The parameter, attr, can only be a top-level attribute of items or
+# an attribute in the form "config.x".
+# Set prtmsg to `true` (without quotes) if you want to print violation messages.
+# If you want to match null, set expr to "null".
+filter_attribute_matches_regex = func(items, attr, expr, prtmsg) {
+	violators = {}
+	messages = {}
+	for items as index, item {
+		val = evaluate_attribute(item, attr) else null
+		if val is null {
+			val = "null"
+		}
+		# Process lists and maps
+		if types.type_of(val) in ["list", "map"] {
+			message = ""
+			# Check each item of list or map
+			for val as i, v {
+				if v matches expr {
+					# Add to the warning message
+					message += to_string(index) + " has " + to_string(attr) +
+						" with value " +
+						to_string(v) +
+						" that matches the regex " +
+						to_string(expr) +
+						"\n"
+				}
+				if message is not "" {
+					# Add the item and warning message to the violators list
+					violators[index] = item
+					messages[index] = message
+					if prtmsg {
+						print(message)
+					}
+				} // end message not ""
+			} // end for
+		} else {
+			# Process single item
+			if val matches expr {
+				# Add the item and a warning message to the violators list
+				message = to_string(index) + " has " + to_string(attr) +
+					" with value " +
+					to_string(val) +
+					" that matches the regex " +
+					to_string(expr)
+				violators[index] = item
+				messages[index] = message
+				if prtmsg {
+					print(message)
+				}
+			} // end if single item not matches
+		} // end single item
+	} // end for items
+	return {"items": violators, "messages": messages}
+}
+
+### get_module_source ###
+# Get the module source from a module address
+# Note that the module_address in many collections in the tfplan/v2, tfconfig/v2,
+# and tfstate/v2 imports gives the labels used in the module blocks.
+# For instance, a module_address like "module.A.module.B" means that the current
+# item is in a module with label "B" that is a module with label "A". But that
+# does not give you the source the module labeled "B".
+# But if you want to limit creation of resources to specific modules based on
+# their source, you need the module source.  This function computes it.
+get_module_source = func(module_address) {
+	# Check for root module
+	if module_address is "" {
+		return "root"
+	} else {
+		# Find parent module
+		module_segments = strings.split(module_address, ".")
+		num_segments = length(module_segments)
+		parent_module = strings.join(module_segments[0 : num_segments - 2], ".")
+		current_module_name = module_segments[num_segments - 1]
+
+		# Find module call that called current module
+		if parent_module is "" {
+			# parent module is root module
+			mc = tfconfig.module_calls[current_module_name]
+		} else {
+			# parent module is not root module
+			mc = tfconfig.module_calls[parent_module + ":" + current_module_name]
+		}
+
+		# Set source from the module call
+		module_source = mc.source
+
+		return module_source
+	}
+}
+
+### get_ancestor_module_source ###
+# Get the module source of the first ancestor module from a module address that
+# is not a local module (one having source starting with "./" or "../").
+# Note that the module_address in many collections in the tfplan/v2, tfconfig/v2,
+# and tfstate/v2 imports gives the labels used in the module blocks.
+# For instance, a module_address like "module.A.module.B" means that the current
+# item is in a module with label "B" that is a module with label "A". But that
+# does not give you the source the module labeled "B".
+# But if you want to limit creation of resources to specific modules based on
+# their source, you need the module source.  This function computes it for
+# the first ancestor module that is not a local module.
+get_ancestor_module_source = func(module_address) {
+	# Check for root module
+	if module_address is "" {
+		return "root"
+	} else {
+		# Find parent module
+		module_segments = strings.split(module_address, ".")
+		num_segments = length(module_segments)
+		parent_module = strings.join(module_segments[0 : num_segments - 2], ".")
+		current_module_name = module_segments[num_segments - 1]
+
+		# Find module call that called current module
+		if parent_module is "" {
+			# parent module is root module
+			mc = tfconfig.module_calls[current_module_name]
+		} else {
+			# parent module is not root module
+			mc = tfconfig.module_calls[parent_module + ":" + current_module_name]
+		}
+
+		# Set source from the module call
+		module_source = mc.source
+
+		# Check to see if current module source is a nested module
+		if strings.has_prefix(module_source, "./") or strings.has_prefix(module_source, "../") {
+			return get_ancestor_module_source(parent_module)
+		} else {
+			return module_source
+		}
+
+	}
+}
+
+### get_parent_module_address ###
+# Get the address of the parent module of a module from the module address
+# return "root" if the given module_address is "" (the root module).
+get_parent_module_address = func(module_address) {
+	# Check for root module
+	if module_address is "" {
+		return "root"
+	} else {
+		# Find parent module
+		module_segments = strings.split(module_address, ".")
+		num_segments = length(module_segments)
+		parent_module = strings.join(module_segments[0 : num_segments - 2], ".")
+		current_module_name = module_segments[num_segments - 1]
+
+		return parent_module
+	}
+}

--- a/common-functions/tfplan-functions/docs/evaluate_attribute.md
+++ b/common-functions/tfplan-functions/docs/evaluate_attribute.md
@@ -1,0 +1,29 @@
+# evaluate_attribute
+This function evaluates the value of an attribute within a resource, data source, or block. The attribute can be deeply nested.
+
+## Sentinel Module
+This function is contained in the [tfplan-functions.sentinel](../tfplan-functions.sentinel) module.
+
+## Declaration
+`evaluate_attribute = func(r, attribute)`
+
+## Arguments
+* **r**: a single resource or block containing an attribute whose value you want to determine. The function converts a plain resource reference like `rc` tp `rc.change.after`; if you want to evaluate the previous state, pass `rc.change.before`.
+* **attribute**: a string giving the attribute. If the attribute is nested, the various blocks containing it should be delimited with periods (`.`). Indices of lists should not include brackets and should start with 0. So, you would use `boot_disk.0.initialize_params.0.image` rather than `boot_disk[0].initialize_params[0].image`. If `r` represents a block, then `attribute` should be specified relative to that block.
+
+In practice, this function is only called by the filter functions, so the specification of the `attribute` parameter will be done when calling them.
+
+## Common Functions Used
+This function calls itself recursively to support nested attributes of resources and blocks.
+
+## What It Returns
+This function returns the value of the attribute of the resource or block. The type will vary depending on what kind of attribute is evaluated.
+
+## What It Prints
+This function does not print anything.
+
+## Examples
+This function is called by all of the filter functions in the tfplan-functions.sentinel module. Here is a typical example:
+```
+v = evaluate_attribute(rc, attr) else null
+```

--- a/common-functions/tfplan-functions/docs/filter_attribute_contains_items_from_list.md
+++ b/common-functions/tfplan-functions/docs/filter_attribute_contains_items_from_list.md
@@ -1,0 +1,32 @@
+# filter_attribute_contains_items_from_list
+This function filters a collection of resources, data sources, or blocks to those with an attribute that contains any members of a given list. A policy would call it when it does not want the attribute to contain any members of the list.
+
+## Sentinel Module
+This function is contained in the [tfplan-functions.sentinel](../tfplan-functions.sentinel) module.
+
+## Declaration
+`filter_attribute_contains_items_from_list = func(resources, attr, forbidden, prtmsg)`
+
+## Arguments
+* **resources**: a map of resources derived from [`tfplan.resource_changes`](https://www.terraform.io/docs/cloud/sentinel/import/tfplan-v2.html#the-resource_changes-collection) or a list of blocks returned by the `find_blocks` function.
+* **attr**: the name of a resource attribute given as a string that should not contain any items in a given list. The attribute should be a list or a map. If the attribute is nested, the various blocks containing it should be delimited with periods (`.`). Indices of lists should not include brackets and should start with 0. So, you would use `boot_disk.0.initialize_params` rather than `boot_disk[0].initialize_params`.
+* **forbidden**: a list of values the attribute should not contain. If you want to disallow null, include "null" in the list.
+* **prtmsg**: a boolean indicating whether violation messages should be printed (if `true`) or not (if `false`).
+
+## Common Functions Used
+This function calls the [evaluate_attribute](./evaluate_attribute.md) and the [to_string](./to_string.md) functions.
+
+## What It Returns
+This function returns a map with two maps, `resources` and `messages`, both of which are indexed by the complete [addresses](https://www.terraform.io/docs/internals/resource-addressing.html) of the resources, data sources, or blocks that meet the condition of the filter function. The `resources` map contains the actual resource instances for which the attribute (`attr`) contains any items of the list (`forbidden`) while the `messages` map contains the violation messages associated with those instances.
+
+## What It Prints
+This function prints the violation messages if the parameter, `prtmsg`, was set to `true`. Otherwise, it does not print anything.
+
+## Examples
+Here is an example of calling this function, assuming that the tfplan-functions.sentinel file that contains it has been imported with the alias `plan`:
+```
+violatingSGRules = plan.filter_attribute_contains_items_from_list(SGIngressRules,
+                  "cidr_blocks",forbidden_cidrs, true)
+```
+
+This function is used by the [restrict-ingress-sg-rule-cidr-blocks.sentinel (AWS)](../../../aws/restrict-ingress-sg-rule-cidr-blocks.sentinel) policy.

--- a/common-functions/tfplan-functions/docs/filter_attribute_contains_items_not_in_list.md
+++ b/common-functions/tfplan-functions/docs/filter_attribute_contains_items_not_in_list.md
@@ -1,0 +1,30 @@
+# filter_attribute_contains_items_not_in_list
+This function filters a collection of resources, data sources, or blocks to those with an attribute that contains any items that are not in a given list. A policy would call it when it wants the attribute to only contain members of the list (but not necessarily all of them).
+
+## Sentinel Module
+This function is contained in the [tfplan-functions.sentinel](../tfplan-functions.sentinel) module.
+
+## Declaration
+`filter_attribute_contains_items_not_in_list = func(resources, attr, allowed, prtmsg)`
+
+## Arguments
+* **resources**: a map of resources derived from [`tfplan.resource_changes`](https://www.terraform.io/docs/cloud/sentinel/import/tfplan-v2.html#the-resource_changes-collection) or a list of blocks returned by the `find_blocks` function.
+* **attr**: the name of a resource attribute given as a string that should should only contain items from a given list. The attribute should be a list or a map. If the attribute is nested, the various blocks containing it should be delimited with periods (`.`). Indices of lists should not include brackets and should start with 0. So, you would use `boot_disk.0.initialize_params` rather than `boot_disk[0].initialize_params`.
+* **allowed**: a list of values the attribute is allowed to contain. If you want to allow null, include "null" in the list.
+* **prtmsg**: a boolean indicating whether violation messages should be printed (if `true`) or not (if `false`).
+
+## Common Functions Used
+This function calls the [evaluate_attribute](./evaluate_attribute.md) and the [to_string](./to_string.md) functions.
+
+## What It Returns
+This function returns a map with two maps, `resources` and `messages`, both of which are indexed by the complete [addresses](https://www.terraform.io/docs/internals/resource-addressing.html) of the resources, data sources, or blocks that meet the condition of the filter function. The `resources` map contains the actual resource instances for which the attribute (`attr`) contains any items that are not in the list (`allowed`) while the `messages` map contains the violation messages associated with those instances.
+
+## What It Prints
+This function prints the violation messages if the parameter, `prtmsg`, was set to `true`. Otherwise, it does not print anything.
+
+## Examples
+Here is an example of calling this function, assuming that the tfplan-functions.sentinel file that contains it has been imported with the alias `plan`:
+```
+violatingIRs = plan.filter_attribute_contains_items_not_in_list(ingressRules,
+               "cidr_blocks", allowed_cidrs, false)
+```

--- a/common-functions/tfplan-functions/docs/filter_attribute_does_not_have_prefix.md
+++ b/common-functions/tfplan-functions/docs/filter_attribute_does_not_have_prefix.md
@@ -1,0 +1,35 @@
+# filter_attribute_does_not_have_prefix
+This function filters a collection of resources, data sources, or blocks to those with an attribute that does have a specified prefix. A policy would call it when it wants the attribute to start with that prefix.
+
+It uses Sentinel's standard [strings](https://docs.hashicorp.com/sentinel/imports/strings/) import.
+
+## Sentinel Module
+This function is contained in the [tfplan-functions.sentinel](../tfplan-functions.sentinel) module.
+
+## Declaration
+`filter_attribute_does_not_have_prefix = func(resources, attr, prefix, prtmsg)`
+
+## Arguments
+* **resources**: a map of resources derived from [`tfplan.resource_changes`](https://www.terraform.io/docs/cloud/sentinel/import/tfplan-v2.html#the-resource_changes-collection) or a list of blocks returned by the `find_blocks` function.
+* **attr**: the name of a resource attribute given as a string that should start with the given prefix. If the attribute is nested, the various blocks containing it should be delimited with periods (`.`). Indices of lists should not include brackets and should start with 0. So, you would use `boot_disk.0.initialize_params.0.image` rather than `boot_disk[0].initialize_params[0].image`.
+* **prefix**: the prefix that the attribute should start with.
+* **prtmsg**: a boolean indicating whether violation messages should be printed (if `true`) or not (if `false`).
+
+## Common Functions Used
+This function calls the [evaluate_attribute](./evaluate_attribute.md) and the [to_string](./to_string.md) functions.
+
+## What It Returns
+This function returns a map with two maps, `resources` and `messages`, both of which are indexed by the complete [addresses](https://www.terraform.io/docs/internals/resource-addressing.html) of the resources, data sources, or blocks that meet the condition of the filter function. The `resources` map contains the actual resource instances for which the attribute (`attr`) does not start with `prefix`, while the `messages` map contains the violation messages associated with those instances.
+
+## What It Prints
+This function prints the violation messages if the parameter, `prtmsg`, was set to `true`. Otherwise, it does not print anything.
+
+## Examples
+Here are some examples of calling this function, assuming that the tfplan-functions.sentinel file that contains it has been imported with the alias `plan`:
+```
+violatingAccessKeys = plan.filter_attribute_does_not_have_prefix(allAccessKeys,
+                      "pgp_key", "keybase:", true)
+
+violatingEC2Instances = plan.filter_attribute_does_not_have_prefix(
+                        allEC2Instances, "instance_type", "m5.", true)
+```

--- a/common-functions/tfplan-functions/docs/filter_attribute_does_not_have_suffix.md
+++ b/common-functions/tfplan-functions/docs/filter_attribute_does_not_have_suffix.md
@@ -1,0 +1,35 @@
+# filter_attribute_does_not_have_suffix
+This function filters a collection of resources, data sources, or blocks to those with an attribute that does have a specified suffix. A policy would call it when it wants the attribute to end with that suffix.
+
+It uses Sentinel's standard [strings](https://docs.hashicorp.com/sentinel/imports/strings/) import.
+
+## Sentinel Module
+This function is contained in the [tfplan-functions.sentinel](../tfplan-functions.sentinel) module.
+
+## Declaration
+`filter_attribute_does_not_have_suffix = func(resources, attr, suffix, prtmsg)`
+
+## Arguments
+* **resources**: a map of resources derived from [`tfplan.resource_changes`](https://www.terraform.io/docs/cloud/sentinel/import/tfplan-v2.html#the-resource_changes-collection) or a list of blocks returned by the `find_blocks` function.
+* **attr**: the name of a resource attribute given as a string that should end with the given suffix. If the attribute is nested, the various blocks containing it should be delimited with periods (`.`). Indices of lists should not include brackets and should start with 0. So, you would use `boot_disk.0.initialize_params.0.image` rather than `boot_disk[0].initialize_params[0].image`.
+* **suffix**: the suffix that the attribute should end with.
+* **prtmsg**: a boolean indicating whether violation messages should be printed (if `true`) or not (if `false`).
+
+## Common Functions Used
+This function calls the [evaluate_attribute](./evaluate_attribute.md) and the [to_string](./to_string.md) functions.
+
+## What It Returns
+This function returns a map with two maps, `resources` and `messages`, both of which are indexed by the complete [addresses](https://www.terraform.io/docs/internals/resource-addressing.html) of the resources, data sources, or blocks that meet the condition of the filter function. The `resources` map contains the actual resource instances for which the attribute (`attr`) does not end with `suffix`, while the `messages` map contains the violation messages associated with those instances.
+
+## What It Prints
+This function prints the violation messages if the parameter, `prtmsg`, was set to `true`. Otherwise, it does not print anything.
+
+## Examples
+Here are some examples of calling this function, assuming that the tfplan-functions.sentinel file that contains it has been imported with the alias `plan`:
+```
+violatingS3Buckets = plan.filter_attribute_does_not_have_suffix(allS3Buckets,
+                      "acl", "-full-control", true)
+
+violatingGCESubnets = plan.filter_attribute_does_not_have_suffix(
+                        allGCESubnets, "ip_cidr_range", "/24", true)
+```

--- a/common-functions/tfplan-functions/docs/filter_attribute_does_not_match_regex.md
+++ b/common-functions/tfplan-functions/docs/filter_attribute_does_not_match_regex.md
@@ -1,0 +1,35 @@
+# filter_attribute_does_not_match_regex
+This function filters a collection of resources, data sources, or blocks to those with an attribute that does not match a given regular expression (regex). A policy would call it when it wants the attribute to match that regex.
+
+It uses the Sentinel [matches](https://docs.hashicorp.com/sentinel/language/spec/#matches-operator) operator which uses [RE2](https://github.com/google/re2/wiki/Syntax) regex.
+
+## Sentinel Module
+This function is contained in the [tfplan-functions.sentinel](../tfplan-functions.sentinel) module.
+
+## Declaration
+`filter_attribute_does_not_match_regex = func(resources, attr, expr, prtmsg)`
+
+## Arguments
+* **resources**: a map of resources derived from [`tfplan.resource_changes`](https://www.terraform.io/docs/cloud/sentinel/import/tfplan-v2.html#the-resource_changes-collection) or a list of blocks returned by the `find_blocks` function.
+* **attr**: the name of a resource attribute given as a string that should match the given regex. If the attribute is nested, the various blocks containing it should be delimited with periods (`.`). Indices of lists should not include brackets and should start with 0. So, you would use `boot_disk.0.initialize_params.0.image` rather than `boot_disk[0].initialize_params[0].image`.
+* **expr**: the regex expression that should be matched. Note that any occurrences of `\` need to be escaped with `\` itself since Sentinel allows certain special characters to be escaped with `\`. For example, if you wanted to match sub-domains of ".acme.com", you would set `expr` to `(.+)\\.acme\\.com$` instead of the more usual `(.+)\.acme\.com$`. If you want to allow `null`, set `expr` to `(<regex>|null)`.
+* **prtmsg**: a boolean indicating whether violation messages should be printed (if `true`) or not (if `false`).
+
+## Common Functions Used
+This function calls the [evaluate_attribute](./evaluate_attribute.md) and the [to_string](./to_string.md) functions.
+
+## What It Returns
+This function returns a map with two maps, `resources` and `messages`, both of which are indexed by the complete [addresses](https://www.terraform.io/docs/internals/resource-addressing.html) of the resources, data sources, or blocks that meet the condition of the filter function. The `resources` map contains the actual resource instances for which the attribute (`attr`) does not match the given regex, `expr`, while the `messages` map contains the violation messages associated with those instances.
+
+## What It Prints
+This function prints the violation messages if the parameter, `prtmsg`, was set to `true`. Otherwise, it does not print anything.
+
+## Examples
+Here are some examples of calling this function, assuming that the tfplan-functions.sentinel file that contains it has been imported with the alias `plan`:
+```
+violatingACMCerts = plan.filter_attribute_does_not_match_regex(allACMCerts,
+                    "domain_name", "(.+)\\.hashidemos\\.io$", true)
+
+violatingAccessKeys = plan.filter_attribute_does_not_match_regex(allAccessKeys,
+                      "pgp_key", "^keybase:(.+)", true)
+```

--- a/common-functions/tfplan-functions/docs/filter_attribute_greater_than_equal_to_value.md
+++ b/common-functions/tfplan-functions/docs/filter_attribute_greater_than_equal_to_value.md
@@ -1,0 +1,32 @@
+# filter_attribute_greater_than_equal_to_value
+This function filters a collection of resources, data sources, or blocks to those with an attribute that is greater than or equal to a given numeric value. A policy would call it when it wants the attribute to be less than the given value.
+
+## Sentinel Module
+This function is contained in the [tfplan-functions.sentinel](../tfplan-functions.sentinel) module.
+
+## Declaration
+`filter_attribute_greater_than_equal_to_value = func(resources, attr, value, prtmsg)`
+
+## Arguments
+* **resources**: a map of resources derived from [`tfplan.resource_changes`](https://www.terraform.io/docs/cloud/sentinel/import/tfplan-v2.html#the-resource_changes-collection) or a list of blocks returned by the `find_blocks` function.
+* **attr**: the name of a resource attribute given as a string that should be less than or equal to a given value. If the attribute is nested, the various blocks containing it should be delimited with periods (`.`). Indices of lists should not include brackets and should start with 0. So, you would use `boot_disk.0.initialize_params.0.image` rather than `boot_disk[0].initialize_params[0].image`.
+* **value**: the value of the attribute should be less than the given value. This should be an integer or a float.
+* **prtmsg**: a boolean indicating whether violation messages should be printed (if `true`) or not (if `false`).
+
+## Common Functions Used
+This function calls the [evaluate_attribute](./evaluate_attribute.md) and the [to_string](./to_string.md) functions.
+
+## What It Returns
+This function returns a map with two maps, `resources` and `messages`, both of which are indexed by the complete [addresses](https://www.terraform.io/docs/internals/resource-addressing.html) of the resources, data sources, or blocks that meet the condition of the filter function. The `resources` map contains the actual resource instances for which the attribute (`attr`) is greater than or equal to the given value, `value`, while the `messages` map contains the violation messages associated with those instances.
+
+## What It Prints
+This function prints the violation messages if the parameter, `prtmsg`, was set to `true`. Otherwise, it does not print anything.
+
+## Examples
+Here is an example of calling this function, assuming that the tfplan-functions.sentinel file that contains it has been imported with the alias `plan`:
+```
+violatingToPortGreater = plan.filter_attribute_greater_than_equal_to_value(ingressRules,
+								"to_port", forbidden_to_port, false)
+```
+
+This function is used by the policies [restrict-ingress-sg-rule-ssh.sentinel (AWS)](../../../aws/restrict-ingress-sg-rule-ssh.sentinel), [restrict-ingress-sg-rule-rdp.sentinel (AWS)](../../../aws/restrict-ingress-sg-rule-rdp.sentinel)

--- a/common-functions/tfplan-functions/docs/filter_attribute_greater_than_value.md
+++ b/common-functions/tfplan-functions/docs/filter_attribute_greater_than_value.md
@@ -1,0 +1,39 @@
+# filter_attribute_greater_than_value
+This function filters a collection of resources, data sources, or blocks to those with an attribute that is greater than a given numeric value. A policy would call it when it wants the attribute to be less than or equal to the given value.
+
+## Sentinel Module
+This function is contained in the [tfplan-functions.sentinel](../tfplan-functions.sentinel) module.
+
+## Declaration
+`filter_attribute_greater_than_value = func(resources, attr, value, prtmsg)`
+
+## Arguments
+* **resources**: a map of resources derived from [`tfplan.resource_changes`](https://www.terraform.io/docs/cloud/sentinel/import/tfplan-v2.html#the-resource_changes-collection) or a list of blocks returned by the `find_blocks` function.
+* **attr**: the name of a resource attribute given as a string that should be less than or equal to a given value. If the attribute is nested, the various blocks containing it should be delimited with periods (`.`). Indices of lists should not include brackets and should start with 0. So, you would use `boot_disk.0.initialize_params.0.image` rather than `boot_disk[0].initialize_params[0].image`.
+* **value**: the value the attribute should be less than or equal to. This should be an integer or a float.
+* **prtmsg**: a boolean indicating whether violation messages should be printed (if `true`) or not (if `false`).
+
+## Common Functions Used
+This function calls the [evaluate_attribute](./evaluate_attribute.md) and the [to_string](./to_string.md) functions.
+
+## What It Returns
+This function returns a map with two maps, `resources` and `messages`, both of which are indexed by the complete [addresses](https://www.terraform.io/docs/internals/resource-addressing.html) of the resources, data sources, or blocks that meet the condition of the filter function. The `resources` map contains the actual resource instances for which the attribute (`attr`) is greater than the given value, `value`, while the `messages` map contains the violation messages associated with those instances.
+
+## What It Prints
+This function prints the violation messages if the parameter, `prtmsg`, was set to `true`. Otherwise, it does not print anything.
+
+## Examples
+Here are some examples of calling this function, assuming that the tfplan-functions.sentinel file that contains it has been imported with the alias `plan`:
+```
+highCPUVMs = plan.filter_attribute_greater_than_value(allVMs,
+             "num_cpus", maxCPUs, true)
+
+
+highMemoryVMs = plan.filter_attribute_greater_than_value(allVMs,
+                "memory", maxMemory, true)
+
+violatingDisks = plan.filter_attribute_greater_than_value(disks,
+                 "size", maxDiskSize, false)
+```
+
+This function is used by the policies [restrict-vm-cpu-and-memory.sentinel (VMware)](../../../vmware/restrict-vm-cpu-and-memory.sentinel), [restrict-vm-disk-size.sentinel (VMware)](../../../vmware/restrict-vm-disk-size.sentinel)

--- a/common-functions/tfplan-functions/docs/filter_attribute_has_prefix.md
+++ b/common-functions/tfplan-functions/docs/filter_attribute_has_prefix.md
@@ -1,0 +1,35 @@
+# filter_attribute_has_prefix
+This function filters a collection of resources, data sources, or blocks to those with an attribute that has a specified prefix. A policy would call it when it wants the attribute to not start with that prefix.
+
+It uses Sentinel's standard [strings](https://docs.hashicorp.com/sentinel/imports/strings/) import.
+
+## Sentinel Module
+This function is contained in the [tfplan-functions.sentinel](../tfplan-functions.sentinel) module.
+
+## Declaration
+`filter_attribute_has_prefix = func(resources, attr, prefix, prtmsg)`
+
+## Arguments
+* **resources**: a map of resources derived from [`tfplan.resource_changes`](https://www.terraform.io/docs/cloud/sentinel/import/tfplan-v2.html#the-resource_changes-collection) or a list of blocks returned by the `find_blocks` function.
+* **attr**: the name of a resource attribute given as a string that should not start with the given prefix. If the attribute is nested, the various blocks containing it should be delimited with periods (`.`). Indices of lists should not include brackets and should start with 0. So, you would use `boot_disk.0.initialize_params.0.image` rather than `boot_disk[0].initialize_params[0].image`.
+* **prefix**: the prefix that the attribute should not start with.
+* **prtmsg**: a boolean indicating whether violation messages should be printed (if `true`) or not (if `false`).
+
+## Common Functions Used
+This function calls the [evaluate_attribute](./evaluate_attribute.md) and the [to_string](./to_string.md) functions.
+
+## What It Returns
+This function returns a map with two maps, `resources` and `messages`, both of which are indexed by the complete [addresses](https://www.terraform.io/docs/internals/resource-addressing.html) of the resources, data sources, or blocks that meet the condition of the filter function. The `resources` map contains the actual resource instances for which the attribute (`attr`) starts with `prefix`, while the `messages` map contains the violation messages associated with those instances.
+
+## What It Prints
+This function prints the violation messages if the parameter, `prtmsg`, was set to `true`. Otherwise, it does not print anything.
+
+## Examples
+Here are some examples of calling this function, assuming that the tfplan-functions.sentinel file that contains it has been imported with the alias `plan`:
+```
+violatingAccessKeys = plan.filter_attribute_has_prefix(allAccessKeys,
+                      "pgp_key", "keybase:", true)
+
+violatingAzureVMs = plan.filter_attribute_has_prefix(
+                        allAzureVMs, "vm_size", "Standard_", true)
+```

--- a/common-functions/tfplan-functions/docs/filter_attribute_has_suffix.md
+++ b/common-functions/tfplan-functions/docs/filter_attribute_has_suffix.md
@@ -1,0 +1,35 @@
+# filter_attribute_has_suffix
+This function filters a collection of resources, data sources, or blocks to those with an attribute that has a specified suffix. A policy would call it when it wants the attribute to not end with that suffix.
+
+It uses Sentinel's standard [strings](https://docs.hashicorp.com/sentinel/imports/strings/) import.
+
+## Sentinel Module
+This function is contained in the [tfplan-functions.sentinel](../tfplan-functions.sentinel) module.
+
+## Declaration
+`filter_attribute_has_suffix = func(resources, attr, suffix, prtmsg)`
+
+## Arguments
+* **resources**: a map of resources derived from [`tfplan.resource_changes`](https://www.terraform.io/docs/cloud/sentinel/import/tfplan-v2.html#the-resource_changes-collection) or a list of blocks returned by the `find_blocks` function.
+* **attr**: the name of a resource attribute given as a string that should not end with the given suffix. If the attribute is nested, the various blocks containing it should be delimited with periods (`.`). Indices of lists should not include brackets and should start with 0. So, you would use `boot_disk.0.initialize_params.0.image` rather than `boot_disk[0].initialize_params[0].image`.
+* **suffix**: the suffix that the attribute should not end with.
+* **prtmsg**: a boolean indicating whether violation messages should be printed (if `true`) or not (if `false`).
+
+## Common Functions Used
+This function calls the [evaluate_attribute](./evaluate_attribute.md) and the [to_string](./to_string.md) functions.
+
+## What It Returns
+This function returns a map with two maps, `resources` and `messages`, both of which are indexed by the complete [addresses](https://www.terraform.io/docs/internals/resource-addressing.html) of the resources, data sources, or blocks that meet the condition of the filter function. The `resources` map contains the actual resource instances for which the attribute (`attr`) ends with `suffix`, while the `messages` map contains the violation messages associated with those instances.
+
+## What It Prints
+This function prints the violation messages if the parameter, `prtmsg`, was set to `true`. Otherwise, it does not print anything.
+
+## Examples
+Here are some examples of calling this function, assuming that the tfplan-functions.sentinel file that contains it has been imported with the alias `plan`:
+```
+violatingS3Buckets = plan.filter_attribute_has_suffix(allS3Buckets,
+                      "acl", "-full-control", true)
+
+violatingGCESubnets = plan.filter_attribute_has_suffix(
+                        allGCESubnets, "ip_cidr_range", "/8", true)
+```

--- a/common-functions/tfplan-functions/docs/filter_attribute_in_list.md
+++ b/common-functions/tfplan-functions/docs/filter_attribute_in_list.md
@@ -1,0 +1,36 @@
+# filter_attribute_in_list
+This function filters a collection of resources, data sources, or blocks to those with an attribute contained in a provided list. A policy would call it when it does not want the attribute set to any member of the list.
+
+## Sentinel Module
+This function is contained in the [tfplan-functions.sentinel](../tfplan-functions.sentinel) module.
+
+## Declaration
+`filter_attribute_in_list = func(resources, attr, forbidden, prtmsg)`
+
+## Arguments
+* **resources**: a map of resources derived from [`tfplan.resource_changes`](https://www.terraform.io/docs/cloud/sentinel/import/tfplan-v2.html#the-resource_changes-collection) or a list of blocks returned by the `find_blocks` function.
+* **attr**: the name of a resource attribute given as a string that must not be in a given list. If the attribute is nested, the various blocks containing it should be delimited with periods (`.`). Indices of lists should not include brackets and should start with 0. So, you would use `boot_disk.0.initialize_params.0.image` rather than `boot_disk[0].initialize_params[0].image`.
+* **forbidden**: a list of values the attribute is forbidden to have. If you want to disallow null, include "null" in the list.
+* **prtmsg**: a boolean indicating whether violation messages should be printed (if `true`) or not (if `false`).
+
+## Common Functions Used
+This function calls the [evaluate_attribute](./evaluate_attribute.md) and the [to_string](./to_string.md) functions.
+
+## What It Returns
+This function returns a map with two maps, `resources` and `messages`, both of which are indexed by the complete [addresses](https://www.terraform.io/docs/internals/resource-addressing.html) of the resources, data sources, or blocks that meet the condition of the filter function. The `resources` map contains the actual resource instances for which the attribute (`attr`) is in in the list (`forbidden`) while the `messages` map contains the violation messages associated with those instances.
+
+## What It Prints
+This function prints the violation messages if the parameter, `prtmsg`, was set to `true`. Otherwise, it does not print anything.
+
+## Examples
+Here are some examples of calling this function, assuming that the tfplan-functions.sentinel file that contains it has been imported with the alias `plan`:
+```
+violatingEC2Instances = plan.filter_attribute_in_list(allEC2Instances,
+                        "instance_type", forbidden_types, true)
+
+violatingAzureVMs = plan.filter_attribute_in_list(allAzureVMs,
+                    "vm_size", forbidden_sizes, true)
+
+violatingGCEInstances = plan.filter_attribute_in_list(allGCEInstances,
+                        "machine_type", forbidden_types, true)
+```

--- a/common-functions/tfplan-functions/docs/filter_attribute_is_not_value.md
+++ b/common-functions/tfplan-functions/docs/filter_attribute_is_not_value.md
@@ -1,0 +1,39 @@
+# filter_attribute_is_not_value
+This function filters a collection of resources, data sources, or blocks to those with an attribute that is not equal to a given value. A policy would call it when it wants the attribute to equal the given value.
+
+## Sentinel Module
+This function is contained in the [tfplan-functions.sentinel](../tfplan-functions.sentinel) module.
+
+## Declaration
+`filter_attribute_is_not_value = func(resources, attr, value, prtmsg)`
+
+## Arguments
+* **resources**: a map of resources derived from [`tfplan.resource_changes`](https://www.terraform.io/docs/cloud/sentinel/import/tfplan-v2.html#the-resource_changes-collection) or a list of blocks returned by the `find_blocks` function.
+* **attr**: the name of a resource attribute given as a string that should equal a given value. If the attribute is nested, the various blocks containing it should be delimited with periods (`.`). Indices of lists should not include brackets and should start with 0. So, you would use `boot_disk.0.initialize_params.0.image` rather than `boot_disk[0].initialize_params[0].image`.
+* **value**: the value the attribute should have. This can be any primitive data type.
+* **prtmsg**: a boolean indicating whether violation messages should be printed (if `true`) or not (if `false`).
+
+## Common Functions Used
+This function calls the [evaluate_attribute](./evaluate_attribute.md) and the [to_string](./to_string.md) functions.
+
+## What It Returns
+This function returns a map with two maps, `resources` and `messages`, both of which are indexed by the complete [addresses](https://www.terraform.io/docs/internals/resource-addressing.html) of the resources, data sources, or blocks that meet the condition of the filter function. The `resources` map contains the actual resource instances for which the attribute (`attr`) is not equal to the given value, `value`, while the `messages` map contains the violation messages associated with those instances.
+
+## What It Prints
+This function prints the violation messages if the parameter, `prtmsg`, was set to `true`. Otherwise, it does not print anything.
+
+## Examples
+Here are some examples of calling this function, assuming that the tfplan-functions.sentinel file that contains it has been imported with the alias `plan`:
+```
+nonPrivateS3Buckets = plan.filter_attribute_is_not_value(allS3Buckets,
+                      "acl", "private", true)
+
+nonEncryptedS3Buckets = plan.filter_attribute_is_not_value(allS3Buckets,
+  "server_side_encryption_configuration.0.rule.0.apply_server_side_encryption_by_default.0.sse_algorithm",
+  "aws:kms", true)
+
+violatingAzureAppServices = plan.filter_attribute_is_not_value(allAzureAppServices,
+                            "https_only", true, true)
+```
+
+This function is used by the [require-private-acl-and-kms-for-s3-buckets.sentinel (AWS)](../../../aws/require-private-acl-and-kms-for-s3-buckets.sentinel) and [restrict-app-service-to-https.sentinel (Azure)](../../../azure/restrict-app-service-to-https.sentinel) policies.

--- a/common-functions/tfplan-functions/docs/filter_attribute_is_value.md
+++ b/common-functions/tfplan-functions/docs/filter_attribute_is_value.md
@@ -1,0 +1,34 @@
+# filter_attribute_is_value
+This function filters a collection of resources, data sources, or blocks to those with an attribute that is equal to a given value. A policy would call it when it wants the attribute to not equal the given value.
+
+## Sentinel Module
+This function is contained in the [tfplan-functions.sentinel](../tfplan-functions.sentinel) module.
+
+## Declaration
+`filter_attribute_is_value = func(resources, attr, value, prtmsg)`
+
+## Arguments
+* **resources**: a map of resources derived from [`tfplan.resource_changes`](https://www.terraform.io/docs/cloud/sentinel/import/tfplan-v2.html#the-resource_changes-collection) or a list of blocks returned by the `find_blocks` function.
+* **attr**: the name of a resource attribute given as a string that should not equal a given value. If the attribute is nested, the various blocks containing it should be delimited with periods (`.`). Indices of lists should not include brackets and should start with 0. So, you would use `boot_disk.0.initialize_params.0.image` rather than `boot_disk[0].initialize_params[0].image`.
+* **value**: the value the attribute should not have. This can be any primitive data type. If you want to match null, set value to "null".
+* **prtmsg**: a boolean indicating whether violation messages should be printed (if `true`) or not (if `false`).
+
+## Common Functions Used
+This function calls the [evaluate_attribute](./evaluate_attribute.md) and the [to_string](./to_string.md) functions.
+
+## What It Returns
+This function returns a map with two maps, `resources` and `messages`, both of which are indexed by the complete [addresses](https://www.terraform.io/docs/internals/resource-addressing.html) of the resources, data sources, or blocks that meet the condition of the filter function. The `resources` map contains the actual resource instances for which the attribute (`attr`) is equal to the given value, `value`, while the `messages` map contains the violation messages associated with those instances.
+
+## What It Prints
+This function prints the violation messages if the parameter, `prtmsg`, was set to `true`. Otherwise, it does not print anything.
+
+## Examples
+Here are some examples of calling this function, assuming that the tfplan-functions.sentinel file that contains it has been imported with the alias `plan`:
+```
+nonPrivateS3Buckets = plan.filter_attribute_is_value(allS3Buckets,
+                      "acl", "public_read", true)
+
+
+violatingAzureAppServices = plan.filter_attribute_is_value(allAzureAppServices,
+                            "https_only", false, true)
+```

--- a/common-functions/tfplan-functions/docs/filter_attribute_less_than_equal_to_value.md
+++ b/common-functions/tfplan-functions/docs/filter_attribute_less_than_equal_to_value.md
@@ -1,0 +1,31 @@
+# filter_attribute_less_than_equal_to_value
+This function filters a collection of resources, data sources, or blocks to those with an attribute that is less than or equal to a given numeric value. A policy would call it when it wants the attribute to be greater than the given value.
+
+## Sentinel Module
+This function is contained in the [tfplan-functions.sentinel](../tfplan-functions.sentinel) module.
+
+## Declaration
+`filter_attribute_less_than_equal_to_value = func(resources, attr, value, prtmsg)`
+
+## Arguments
+* **resources**: a map of resources derived from [`tfplan.resource_changes`](https://www.terraform.io/docs/cloud/sentinel/import/tfplan-v2.html#the-resource_changes-collection) or a list of blocks returned by the `find_blocks` function.
+* **attr**: the name of a resource attribute given as a string that should be greater than or equal to a given value. If the attribute is nested, the various blocks containing it should be delimited with periods (`.`). Indices of lists should not include brackets and should start with 0. So, you would use `boot_disk.0.initialize_params.0.image` rather than `boot_disk[0].initialize_params[0].image`.
+* **value**: the value or the attribute should be greater than the given value. This should be an integer or a float.
+* **prtmsg**: a boolean indicating whether violation messages should be printed (if `true`) or not (if `false`).
+
+## Common Functions Used
+This function calls the [evaluate_attribute](./evaluate_attribute.md) and the [to_string](./to_string.md) functions.
+
+## What It Returns
+This function returns a map with two maps, `resources` and `messages`, both of which are indexed by the complete [addresses](https://www.terraform.io/docs/internals/resource-addressing.html) of the resources, data sources, or blocks that meet the condition of the filter function. The `resources` map contains the actual resource instances for which the attribute (`attr`) is less than or equal to the given value, `value`, while the `messages` map contains the violation messages associated with those instances.
+
+## What It Prints
+This function prints the violation messages if the parameter, `prtmsg`, was set to `true`. Otherwise, it does not print anything.
+
+## Examples
+Here is an example of calling this function, assuming that the tfplan-functions.sentinel file that contains it has been imported with the alias `plan`:
+```
+violatingFromPortLess = plan.filter_attribute_less_than_equal_to_value(ingressRules,
+							"from_port", forbidden_from_port, false)
+```
+This function is used by the policies [restrict-ingress-sg-rule-ssh.sentinel (AWS)](../../../aws/restrict-ingress-sg-rule-ssh.sentinel), [restrict-ingress-sg-rule-rdp.sentinel (AWS)](../../../aws/restrict-ingress-sg-rule-rdp.sentinel)

--- a/common-functions/tfplan-functions/docs/filter_attribute_less_than_value.md
+++ b/common-functions/tfplan-functions/docs/filter_attribute_less_than_value.md
@@ -1,0 +1,34 @@
+# filter_attribute_less_than_value
+This function filters a collection of resources, data sources, or blocks to those with an attribute that is less than a given numeric value. A policy would call it when it wants the attribute to be greater than or equal to the given value.
+
+## Sentinel Module
+This function is contained in the [tfplan-functions.sentinel](../tfplan-functions.sentinel) module.
+
+## Declaration
+`filter_attribute_less_than_value = func(resources, attr, value, prtmsg)`
+
+## Arguments
+* **resources**: a map of resources derived from [`tfplan.resource_changes`](https://www.terraform.io/docs/cloud/sentinel/import/tfplan-v2.html#the-resource_changes-collection) or a list of blocks returned by the `find_blocks` function.
+* **attr**: the name of a resource attribute given as a string that should be greater than or equal to a given value. If the attribute is nested, the various blocks containing it should be delimited with periods (`.`). Indices of lists should not include brackets and should start with 0. So, you would use `boot_disk.0.initialize_params.0.image` rather than `boot_disk[0].initialize_params[0].image`.
+* **value**: the value the attribute should be greater than or equal to. This should be an integer or a float.
+* **prtmsg**: a boolean indicating whether violation messages should be printed (if `true`) or not (if `false`).
+
+## Common Functions Used
+This function calls the [evaluate_attribute](./evaluate_attribute.md) and the [to_string](./to_string.md) functions.
+
+## What It Returns
+This function returns a map with two maps, `resources` and `messages`, both of which are indexed by the complete [addresses](https://www.terraform.io/docs/internals/resource-addressing.html) of the resources, data sources, or blocks that meet the condition of the filter function. The `resources` map contains the actual resource instances for which the attribute (`attr`) is less than the given value, `value`, while the `messages` map contains the violation messages associated with those instances.
+
+## What It Prints
+This function prints the violation messages if the parameter, `prtmsg`, was set to `true`. Otherwise, it does not print anything.
+
+## Examples
+Here are some examples of calling this function, assuming that the tfplan-functions.sentinel file that contains it has been imported with the alias `plan`:
+```
+lowCPUVMs = plan.filter_attribute_less_than_value(allVMs,
+             "num_cpus", minCPUs, true)
+
+
+lowMemoryVMs = plan.filter_attribute_less_than_value(allVMs,
+                "memory", minMemory, true)
+```

--- a/common-functions/tfplan-functions/docs/filter_attribute_matches_regex.md
+++ b/common-functions/tfplan-functions/docs/filter_attribute_matches_regex.md
@@ -1,0 +1,35 @@
+# filter_attribute_matches_regex
+This function filters a collection of resources, data sources, or blocks to those with an attribute that matches a given regular expression (regex). A policy would call it when it wants the attribute to not match that regex.
+
+It uses the Sentinel [matches](https://docs.hashicorp.com/sentinel/language/spec/#matches-operator) operator which uses [RE2](https://github.com/google/re2/wiki/Syntax) regex.
+
+## Sentinel Module
+This function is contained in the [tfplan-functions.sentinel](../tfplan-functions.sentinel) module.
+
+## Declaration
+`filter_attribute_matches_regex = func(resources, attr, expr, prtmsg)`
+
+## Arguments
+* **resources**: a map of resources derived from [`tfplan.resource_changes`](https://www.terraform.io/docs/cloud/sentinel/import/tfplan-v2.html#the-resource_changes-collection) or a list of blocks returned by the `find_blocks` function.
+* **attr**: the name of a resource attribute given as a string that should match the given regex. If the attribute is nested, the various blocks containing it should be delimited with periods (`.`). Indices of lists should not include brackets and should start with 0. So, you would use `boot_disk.0.initialize_params.0.image` rather than `boot_disk[0].initialize_params[0].image`.
+* **expr**: the regex expression that should be matched. Note that any occurrences of `\` need to be escaped with `\` itself since Sentinel allows certain special characters to be escaped with `\`. For example, if you did not want to match sub-domains of ".acme.com", you would set `expr` to `(.+)\\.acme\\.com$` instead of the more usual `(.+)\.acme\.com$`. If you want to match null, set expr to "null".
+* **prtmsg**: a boolean indicating whether violation messages should be printed (if `true`) or not (if `false`).
+
+## Common Functions Used
+This function calls the [evaluate_attribute](./evaluate_attribute.md) and the [to_string](./to_string.md) functions.
+
+## What It Returns
+This function returns a map with two maps, `resources` and `messages`, both of which are indexed by the complete [addresses](https://www.terraform.io/docs/internals/resource-addressing.html) of the resources, data sources, or blocks that meet the condition of the filter function. The `resources` map contains the actual resource instances for which the attribute (`attr`) matches the given regex, `expr`, while the `messages` map contains the violation messages associated with those instances.
+
+## What It Prints
+This function prints the violation messages if the parameter, `prtmsg`, was set to `true`. Otherwise, it does not print anything.
+
+## Examples
+Here are some examples of calling this function, assuming that the tfplan-functions.sentinel file that contains it has been imported with the alias `plan`:
+```
+violatingACMCerts = plan.filter_attribute_matches_regex(allACMCerts,
+                    "domain_name", "(.+)\\.hashidemos\\.io$", true)
+
+violatingAccessKeys = plan.filter_attribute_matches_regex(allAccessKeys,
+                      "pgp_key", "^keybase:(.+)", true)
+```

--- a/common-functions/tfplan-functions/docs/filter_attribute_not_contains_list.md
+++ b/common-functions/tfplan-functions/docs/filter_attribute_not_contains_list.md
@@ -1,0 +1,38 @@
+# filter_attribute_not_contains_list
+This function filters a collection of resources, data sources, or blocks to those with an attribute that does not contain all members of a given list. A policy would call it when it wants the attribute to contain all members of the list.
+
+## Sentinel Module
+This function is contained in the [tfplan-functions.sentinel](../tfplan-functions.sentinel) module.
+
+## Declaration
+`filter_attribute_not_contains_list = func(resources, attr, required, prtmsg)`
+
+## Arguments
+* **resources**: a map of resources derived from [`tfplan.resource_changes`](https://www.terraform.io/docs/cloud/sentinel/import/tfplan-v2.html#the-resource_changes-collection) or a list of blocks returned by the `find_blocks` function.
+* **attr**: the name of a resource attribute given as a string that must contain all items from a given list. The attribute should be a list or map. If the attribute is nested, the various blocks containing it should be delimited with periods (`.`). Indices of lists should not include brackets and should start with 0. So, you would use `boot_disk.0.initialize_params` rather than `boot_disk[0].initialize_params`.
+* **required**: a list of values all of which the attribute should contain.
+* **prtmsg**: a boolean indicating whether violation messages should be printed (if `true`) or not (if `false`).
+
+## Common Functions Used
+This function calls the [evaluate_attribute](./evaluate_attribute.md) and the [to_string](./to_string.md) functions.
+
+## What It Returns
+This function returns a map with two maps, `resources` and `messages`, both of which are indexed by the complete [addresses](https://www.terraform.io/docs/internals/resource-addressing.html) of the resources, data sources, or blocks that meet the condition of the filter function. The `resources` map contains the actual resource instances for which the attribute (`attr`) does not contain all items of the list (`required`) while the `messages` map contains the violation messages associated with those instances.
+
+## What It Prints
+This function prints the violation messages if the parameter, `prtmsg`, was set to `true`. Otherwise, it does not print anything.
+
+## Examples
+Here are some examples of calling this function, assuming that the tfplan-functions.sentinel file that contains it has been imported with the alias `plan`:
+```
+violatingEC2Instances = plan.filter_attribute_not_contains_list(allEC2Instances,
+                        "tags", mandatory_tags, true)
+
+violatingAzureVMs = plan.filter_attribute_not_contains_list(allAzureVMs,
+                    "tags", mandatory_tags, true)
+
+violatingGCEInstances = plan.filter_attribute_not_contains_list(allGCEInstances,
+                        "labels", mandatory_labels, true)
+```
+
+This function is used by several policies including [enforce-mandatory-tags.sentinel (AWS)](../../../aws/enforce-mandatory-tags.sentinel), [enforce-mandatory-tags.sentinel (Azure)](../../../azure/enforce-mandatory-tags.sentinel), and [enforce-mandatory-labels.sentinel (GCP)](../../../gcp/enforce-mandatory-labels.sentinel).

--- a/common-functions/tfplan-functions/docs/filter_attribute_not_in_list.md
+++ b/common-functions/tfplan-functions/docs/filter_attribute_not_in_list.md
@@ -1,0 +1,38 @@
+# filter_attribute_not_in_list
+This function filters a collection of resources, data sources, or blocks to those with an attribute that is not contained in a provided list. A policy would call it when it wants the attribute to have a value from the list.
+
+## Sentinel Module
+This function is contained in the [tfplan-functions.sentinel](../tfplan-functions.sentinel) module.
+
+## Declaration
+`filter_attribute_not_in_list = func(resources, attr, allowed, prtmsg)`
+
+## Arguments
+* **resources**: a map of resources derived from [`tfplan.resource_changes`](https://www.terraform.io/docs/cloud/sentinel/import/tfplan-v2.html#the-resource_changes-collection) or a list of blocks returned by the `find_blocks` function.
+* **attr**: the name of a resource attribute given as a string that must be in a given list. If the attribute is nested, the various blocks containing it should be delimited with periods (`.`). Indices of lists should not include brackets and should start with 0. So, you would use `boot_disk.0.initialize_params.0.image` rather than `boot_disk[0].initialize_params[0].image`.
+* **allowed**: a list of values the attribute is allowed to have. If you want to allow null, include "null" in the list.
+* **prtmsg**: a boolean indicating whether violation messages should be printed (if `true`) or not (if `false`).
+
+## Common Functions Used
+This function calls the [evaluate_attribute](./evaluate_attribute.md) and the [to_string](./to_string.md) functions.
+
+## What It Returns
+This function returns a map with two maps, `resources` and `messages`, both of which are indexed by the complete [addresses](https://www.terraform.io/docs/internals/resource-addressing.html) of the resources, data sources, or blocks that meet the condition of the filter function. The `resources` map contains the actual resource instances for which the attribute (`attr`) is not in the list (`allowed`) while the `messages` map contains the violation messages associated with those instances.
+
+## What It Prints
+This function prints the violation messages if the parameter, `prtmsg`, was set to `true`. Otherwise, it does not print anything.
+
+## Examples
+Here are some examples of calling this function, assuming that the tfplan-functions.sentinel file that contains it has been imported with the alias `plan`:
+```
+violatingEC2Instances = plan.filter_attribute_not_in_list(allEC2Instances,
+                        "instance_type", allowed_types, true)
+
+violatingAzureVMs = plan.filter_attribute_not_in_list(allAzureVMs,
+                    "vm_size", allowed_sizes, true)
+
+violatingGCEInstances = plan.filter_attribute_not_in_list(allGCEInstances,
+                        "machine_type", allowed_types, true)
+```
+
+This function is used by many policies including [restrict-ec2-instance-type.sentinel (AWS)](../../../aws/restrict-ec2-instance-type.sentinel), [restrict-vm-size.sentinel (Azure)](../../../azure/restrict-vm-size.sentinel), and [restrict-gce-machine-type.sentinel (GCP)](../../../gcp/restrict-gce-machine-type.sentinel).

--- a/common-functions/tfplan-functions/docs/filter_attribute_was_not_value.md
+++ b/common-functions/tfplan-functions/docs/filter_attribute_was_not_value.md
@@ -1,0 +1,33 @@
+# filter_attribute_was_not_value
+This function filters a collection of resources, data sources, or blocks to those with an attribute that was not equal to a given value. A policy would call it when it wants the attribute to equal the given value, especially when trying to delete a resource. Note that this function passes `rc.change.before` instead of `rc` to the `evaluate_attribute()` function which converts `rc` to `rc.change.after`.
+
+## Sentinel Module
+This function is contained in the [tfplan-functions.sentinel](../tfplan-functions.sentinel) module.
+
+## Declaration
+`filter_attribute_was_not_value = func(resources, attr, value, prtmsg)`
+
+## Arguments
+* **resources**: a map of resources derived from [`tfplan.resource_changes`](https://www.terraform.io/docs/cloud/sentinel/import/tfplan-v2.html#the-resource_changes-collection) or a list of blocks returned by the `find_blocks` function.
+* **attr**: the name of a resource attribute given as a string that should have previously equaled a given value. If the attribute is nested, the various blocks containing it should be delimited with periods (`.`). Indices of lists should not include brackets and should start with 0. So, you would use `boot_disk.0.initialize_params.0.image` rather than `boot_disk[0].initialize_params[0].image`.
+* **value**: the value the attribute should have been equal to. This can be any primitive data type.
+* **prtmsg**: a boolean indicating whether violation messages should be printed (if `true`) or not (if `false`).
+
+## Common Functions Used
+This function calls the [evaluate_attribute](./evaluate_attribute.md) and the [to_string](./to_string.md) functions.
+
+## What It Returns
+This function returns a map with two maps, `resources` and `messages`, both of which are indexed by the complete [addresses](https://www.terraform.io/docs/internals/resource-addressing.html) of the resources, data sources, or blocks that meet the condition of the filter function. The `resources` map contains the actual resource instances for which the attribute (`attr`) is not equal to the given value, `value`, while the `messages` map contains the violation messages associated with those instances.
+
+## What It Prints
+This function prints the violation messages if the parameter, `prtmsg`, was set to `true`. Otherwise, it does not print anything.
+
+## Examples
+Here are some examples of calling this function, assuming that the tfplan-functions.sentinel file that contains it has been imported with the alias `plan`:
+```
+nonPrivateS3Buckets = plan.filter_attribute_was_not_value(allS3Buckets,
+                      "acl", "private", true)
+
+violatingAzureAppServices = plan.filter_attribute_is_not_value(allAzureAppServices,
+                            "https_only", true, true)
+```

--- a/common-functions/tfplan-functions/docs/filter_attribute_was_value.md
+++ b/common-functions/tfplan-functions/docs/filter_attribute_was_value.md
@@ -1,0 +1,35 @@
+# filter_attribute_was_value
+This function filters a collection of resources, data sources, or blocks to those with an attribute that was equal to a given value. A policy would call it when it wants the attribute to not equal the given value, especially when trying to delete a resource. Note that this function passes `rc.change.before` instead of `rc` to the `evaluate_attribute()` function which converts `rc` to `rc.change.after`.
+
+## Sentinel Module
+This function is contained in the [tfplan-functions.sentinel](../tfplan-functions.sentinel) module.
+
+## Declaration
+`filter_attribute_was_value = func(resources, attr, value, prtmsg)`
+
+## Arguments
+* **resources**: a map of resources derived from [`tfplan.resource_changes`](https://www.terraform.io/docs/cloud/sentinel/import/tfplan-v2.html#the-resource_changes-collection) or a list of blocks returned by the `find_blocks` function.
+* **attr**: the name of a resource attribute given as a string that should not have previously equaled a given value. If the attribute is nested, the various blocks containing it should be delimited with periods (`.`). Indices of lists should not include brackets and should start with 0. So, you would use `boot_disk.0.initialize_params.0.image` rather than `boot_disk[0].initialize_params[0].image`.
+* **value**: the value the attribute should not have been equal to. This can be any primitive data type. If you want to match null, set value to "null".
+* **prtmsg**: a boolean indicating whether violation messages should be printed (if `true`) or not (if `false`).
+
+## Common Functions Used
+This function calls the [evaluate_attribute](./evaluate_attribute.md) and the [to_string](./to_string.md) functions.
+
+## What It Returns
+This function returns a map with two maps, `resources` and `messages`, both of which are indexed by the complete [addresses](https://www.terraform.io/docs/internals/resource-addressing.html) of the resources, data sources, or blocks that meet the condition of the filter function. The `resources` map contains the actual resource instances for which the attribute (`attr`) is equal to the given value, `value`, while the `messages` map contains the violation messages associated with those instances.
+
+## What It Prints
+This function prints the violation messages if the parameter, `prtmsg`, was set to `true`. Otherwise, it does not print anything.
+
+## Examples
+Here is an example of calling this function, assuming that the tfplan-functions.sentinel file that contains it has been imported with the alias `plan`:
+```
+violatingRDSInstances = plan.filter_attribute_was_value(RDSInstancesBeingDeleted,
+                        "deletion_protection", true, false)
+
+violatingAzureAppServices = plan.filter_attribute_was_value(allAzureAppServices,
+                            "https_only", true, true)
+```
+
+This function is used by the [protect-against-rds-instance-deletion.sentinel (AWS)](../../../aws/protect-against-rds-instance-deletion.sentinel) policy.

--- a/common-functions/tfplan-functions/docs/find_blocks.md
+++ b/common-functions/tfplan-functions/docs/find_blocks.md
@@ -1,0 +1,31 @@
+# find_blocks
+This function finds all blocks of a specific type under a single resource or block in the current plan using the [tfplan/v2](https://www.terraform.io/docs/cloud/sentinel/import/tfplan-v2.html) import.
+
+## Sentinel Module
+This function is contained in the [tfplan-functions.sentinel](../tfplan-functions.sentinel) module.
+
+## Declaration
+`find_blocks = func(parent, child)`
+
+## Arguments
+* **parent**: a single resource or block of a resource
+* **child**: a string representing the child blocks to be found in the parent.
+
+## Common Functions Used
+None
+
+## What It Returns
+This function returns a single list of child blocks found in the parent resource or block. Each child block is represented by a map.
+
+## What It Prints
+This function does not print anything.
+
+## Examples
+Here are some examples of calling this function, assuming that the tfplan-functions.sentinel file that contains it has been imported with the alias `plan`:
+```
+ingressRules = plan.find_blocks(sg, "ingress")
+
+disks = plan.find_blocks(vm, "disk")
+```
+
+This function is used by the [restrict-ingress-sg-rule-cidr-blocks.sentinel (AWSc)](../../../aws/restrict-ingress-sg-rule-cidr-blocks.sentinel) and [restrict-vm-disk-size.sentinel (VMware)](../../../vmware/restrict-vm-disk-size.sentinel) policies.

--- a/common-functions/tfplan-functions/docs/find_datasources.md
+++ b/common-functions/tfplan-functions/docs/find_datasources.md
@@ -1,0 +1,34 @@
+# find_datasources
+This function finds all data source instances of a specific type that are being created, modified, or read in the current plan using the [tfplan/v2](https://www.terraform.io/docs/cloud/sentinel/import/tfplan-v2.html) import. Data sources with the "no-op" action are also included, but only if their `change.after` attribute is not null.
+
+When evaluating data sources that do not reference any computed values (those known after doing an apply), it is usually better to use the [tfstate/v2](https://www.terraform.io/docs/cloud/sentinel/import/tfstate-v2.html) import and the corresponding [find_datasources](../tfstate-functions/find_datasources.md) function that uses that import.
+
+## Sentinel Module
+This function is contained in the [tfplan-functions.sentinel](../tfplan-functions.sentinel) Sentinel module.
+
+## Declaration
+`find_datasources = func(type)`
+
+## Arguments
+* **type**: the type of datasource to find, given as a string.
+
+## Common Functions Used
+None
+
+## What It Returns
+This function returns a single flat map of data source instances indexed by the complete [addresses](https://www.terraform.io/docs/internals/resource-addressing.html) of the instances. The map is actually a filtered sub-collection of the [`tfplan.resource_changes`](https://www.terraform.io/docs/cloud/sentinel/import/tfplan-v2.html#the-resource_changes-collection) collection.
+
+## What It Prints
+This function does not print anything.
+
+## Examples
+Here are some examples of calling this function, assuming that the tfplan-functions.sentinel file that contains it has been imported with the alias `plan`:
+```
+allAMIs = plan.find_datasources("aws_ami")
+
+allImages = plan.find_datasources("azurerm_image")
+
+allImages = plan.find_datasources("google_compute_image")
+
+allDatastores = plan.find_datasources("vsphere_datastore")
+```

--- a/common-functions/tfplan-functions/docs/find_datasources_being_destroyed.md
+++ b/common-functions/tfplan-functions/docs/find_datasources_being_destroyed.md
@@ -1,0 +1,26 @@
+# find_datasources_being_destroyed
+This function finds all data source instances being destroyed but not re-created in the current plan using the [tfplan/v2](https://www.terraform.io/docs/cloud/sentinel/import/tfplan-v2.html) import.
+
+## Sentinel Module
+This function is contained in the [tfplan-functions.sentinel](../tfplan-functions.sentinel) module.
+
+## Declaration
+`find_datasources_being_destroyed = func()`
+
+## Arguments
+None
+
+## Common Functions Used
+None
+
+## What It Returns
+This function returns a single flat map of data source instances indexed by the complete [addresses](https://www.terraform.io/docs/internals/data source-addressing.html) of the instances. The map is actually a filtered sub-collection of the [`tfplan.data source_changes`](https://www.terraform.io/docs/cloud/sentinel/import/tfplan-v2.html#the-data source_changes-collection) collection.
+
+## What It Prints
+This function does not print anything.
+
+## Examples
+Here is an example of calling this function, assuming that the tfplan-functions.sentinel file that contains it has been imported with the alias `plan`:
+```
+datasourcesBeingDestroyed = plan.find_data sources_being_destroyed()
+```

--- a/common-functions/tfplan-functions/docs/find_datasources_by_provider.md
+++ b/common-functions/tfplan-functions/docs/find_datasources_by_provider.md
@@ -1,0 +1,38 @@
+# find_datasources_by_provider
+This function finds all data source instances for a specific provider that are being created, modified, or read in the current plan using the [tfplan/v2](https://www.terraform.io/docs/cloud/sentinel/import/tfplan-v2.html) import. Data sources with the "no-op" action are also included, but only if their `change.after` attribute is not null.
+
+When evaluating data sources that do not reference any computed values (those known after doing an apply), it is usually better to use the [tfstate/v2](https://www.terraform.io/docs/cloud/sentinel/import/tfstate-v2.html) import and the corresponding [find_datasources](../tfstate-functions/find_datasources.md) function that uses that import.
+
+If you are using Terraform 0.12, use the short form of the provider name such as "null". If you are using Terraform 0.13, you can use the short form or the fully-qualified provider source such as "registry.terraform.io/hashicorp/null", but only use the latter if you are only want to find resources from a specific registry. If you use the short form, the function will reduce `rc.provider_name` for each resource to the short form, but if you use the long form, it will not.
+
+## Sentinel Module
+This function is contained in the [tfplan-functions.sentinel](../tfplan-functions.sentinel) Sentinel module.
+
+## Declaration
+`find_datasources_by_provider = func(provider)`
+
+## Arguments
+* **provider**: the provider, given as a string.
+
+## Common Functions Used
+None
+
+## What It Returns
+This function returns a single flat map of data source instances indexed by the complete [addresses](https://www.terraform.io/docs/internals/resource-addressing.html) of the instances. The map is actually a filtered sub-collection of the [`tfplan.resource_changes`](https://www.terraform.io/docs/cloud/sentinel/import/tfplan-v2.html#the-resource_changes-collection) collection.
+
+## What It Prints
+This function does not print anything.
+
+## Examples
+Here are some examples of calling this function, assuming that the tfplan-functions.sentinel file that contains it has been imported with the alias `plan`:
+```
+allAWSDataSources = plan.find_datasources_by_provider("aws")
+
+allAWSDataSources = plan.find_datasources_by_provider("registry.terraform.io/hashicorp/aws")
+
+allAzureDataSources = plan.find_datasources_by_provider("azurerm")
+
+allGCPDataSources = plan.find_datasources_by_provider("google")
+
+allVMwareDataSources = plan.find_datasources("vsphere")
+```

--- a/common-functions/tfplan-functions/docs/find_resources.md
+++ b/common-functions/tfplan-functions/docs/find_resources.md
@@ -1,0 +1,34 @@
+# find_resources
+This function finds all resource instances of a specific type in the current plan that are being created, modified or read using the [tfplan/v2](https://www.terraform.io/docs/cloud/sentinel/import/tfplan-v2.html) import. Resources with the "no-op" action are also included, but only if their `change.after` attribute is not null.
+
+## Sentinel Module
+This function is contained in the [tfplan-functions.sentinel](../tfplan-functions.sentinel) module.
+
+## Declaration
+`find_resources = func(type)`
+
+## Arguments
+* **type**: the type of resource to find, given as a string.
+
+## Common Functions Used
+None
+
+## What It Returns
+This function returns a single flat map of resource instances indexed by the complete [addresses](https://www.terraform.io/docs/internals/resource-addressing.html) of the instances. The map is actually a filtered sub-collection of the [`tfplan.resource_changes`](https://www.terraform.io/docs/cloud/sentinel/import/tfplan-v2.html#the-resource_changes-collection) collection.
+
+## What It Prints
+This function does not print anything.
+
+## Examples
+Here are some examples of calling this function, assuming that the tfplan-functions.sentinel file that contains it has been imported with the alias `plan`:
+```
+allEC2Instances = plan.find_resources("aws_instance")
+
+allAzureVMs = plan.find_resources("azurerm_virtual_machine")
+
+allGCEInstances = plan.find_resources("google_compute_instance")
+
+allVMs = plan.find_resources("vsphere_virtual_machine")
+```
+
+This function is used by many policies including [restrict-ec2-instance-type.sentinel (AWS)](../../../aws/restrict-ec2-instance-type.sentinel), [restrict-vm-size..sentinel (Azure)](../../../azure/restrict-vm-size..sentinel), [restrict-gce-machine-type.sentinel (GCP)](../../../gcp/restrict-gce-machine-type.sentinel), and [restrict-vm-cpu-and-memory.sentinel (VMware)](../../../vmware/restrict-vm-cpu-and-memory.sentinel).

--- a/common-functions/tfplan-functions/docs/find_resources_being_destroyed.md
+++ b/common-functions/tfplan-functions/docs/find_resources_being_destroyed.md
@@ -1,0 +1,28 @@
+# find_resources_being_destroyed
+This function finds all resource instances being destroyed but not re-created in the current plan using the [tfplan/v2](https://www.terraform.io/docs/cloud/sentinel/import/tfplan-v2.html) import.
+
+## Sentinel Module
+This function is contained in the [tfplan-functions.sentinel](../tfplan-functions.sentinel) module.
+
+## Declaration
+`find_resources_being_destroyed = func()`
+
+## Arguments
+None
+
+## Common Functions Used
+None
+
+## What It Returns
+This function returns a single flat map of resource instances indexed by the complete [addresses](https://www.terraform.io/docs/internals/resource-addressing.html) of the instances. The map is actually a filtered sub-collection of the [`tfplan.resource_changes`](https://www.terraform.io/docs/cloud/sentinel/import/tfplan-v2.html#the-resource_changes-collection) collection.
+
+## What It Prints
+This function does not print anything.
+
+## Examples
+Here is an example of calling this function, assuming that the tfplan-functions.sentinel file that contains it has been imported with the alias `plan`:
+```
+resourcesBeingDestroyed = plan.find_resources_being_destroyed()
+```
+
+This function is used by the [prevent-destruction-of-prohibited-resources.sentinel (Cloud Agnostic)](../../../cloud-agnostic/prevent-destruction-of-prohibited-resources.sentinel) policy.

--- a/common-functions/tfplan-functions/docs/find_resources_by_provider.md
+++ b/common-functions/tfplan-functions/docs/find_resources_by_provider.md
@@ -1,0 +1,36 @@
+# find_resources_by_provider
+This function finds all resource instances for a specific provider in the current plan that are being created, modified, or read using the [tfplan/v2](https://www.terraform.io/docs/cloud/sentinel/import/tfplan-v2.html) import. Resources with the "no-op" action are also included, but only if their `change.after` attribute is not null.
+
+If you are using Terraform 0.12, use the short form of the provider name such as "null". If you are using Terraform 0.13, you can use the short form or the fully-qualified provider source such as "registry.terraform.io/hashicorp/null", but only use the latter if you are only want to find resources from a specific registry. If you use the short form, the function will reduce `rc.provider_name` for each resource to the short form, but if you use the long form, it will not.
+
+## Sentinel Module
+This function is contained in the [tfplan-functions.sentinel](../tfplan-functions.sentinel) module.
+
+## Declaration
+`find_resources_by_provider = func(provider)`
+
+## Arguments
+* **provider**: the provider, given as a string.
+
+## Common Functions Used
+None
+
+## What It Returns
+This function returns a single flat map of resource instances indexed by the complete [addresses](https://www.terraform.io/docs/internals/resource-addressing.html) of the instances. The map is actually a filtered sub-collection of the [`tfplan.resource_changes`](https://www.terraform.io/docs/cloud/sentinel/import/tfplan-v2.html#the-resource_changes-collection) collection.
+
+## What It Prints
+This function does not print anything.
+
+## Examples
+Here are some examples of calling this function, assuming that the tfplan-functions.sentinel file that contains it has been imported with the alias `plan`:
+```
+allAWSResources = plan.find_resources_by_provider("aws")
+
+allAWSResources = plan.find_resources_by_provider("registry.terraform.io/hashicorp/aws")
+
+allAzureResources = plan.find_resources_by_provider("azurerm")
+
+allGCPResources = plan.find_resources_by_provider("google")
+
+allVMwareResources = plan.find_resources_by_provider("vsphere")
+```

--- a/common-functions/tfplan-functions/docs/print_violations.md
+++ b/common-functions/tfplan-functions/docs/print_violations.md
@@ -1,0 +1,40 @@
+# print_violations
+This function prints the violation messages that were previously returned by one of the filter functions of the tfplan-functions.sentinel module. While those filter functions can print the violations messages themselves (if their `prtmsg` parameter is set to `true`), it is sometimes preferable to delay printing of the messages until later in the policy, typically after printing one or more messages giving the address of the resource that violated it.
+
+## Sentinel Module
+This function is contained in the [tfplan-functions.sentinel](../tfplan-functions.sentinel) module.
+
+## Declaration
+`print_violations = func(messages, prefix)`
+
+## Arguments
+* **messages**: a map of messages returned by one of the filter functions.
+* **prefix**: a string that should be printed before each message.
+
+## Common Functions Used
+None
+
+## What It Returns
+This function always returns `true`.
+
+## What It Prints
+This function prints the messages in the `messages` map prefixed with the `prefix` string.
+
+## Examples
+Here are some examples of calling this function, assuming that the tfplan-functions.sentinel file that contains it has been imported with the alias `plan`:
+```
+if length(violatingIRs["messages"]) > 0 {
+  violatingSGsCount += 1
+  print("SG Ingress Violation:", address, "has at least one ingress rule",
+        "with forbidden cidr blocks")
+  plan.print_violations(violatingIRs["messages"], "Ingress Rule")
+}
+
+if length(violatingDisks["messages"]) > 0 {
+  disksValidated = false
+  print(address, "has at least one disk with size greater than", maxDiskSize)
+  plan.print_violations(violatingDisks["messages"], "Disk")
+}
+```
+
+This function is used by the [restrict-ingress-sg-rule-cidr-blocks.sentinel (AWS)](../../../aws/restrict-ingress-sg-rule-cidr-blocks.sentinel) and [restrict-vm-disk-size.sentinel (VMware)](../../../vmware/restrict-vm-disk-size.sentinel).

--- a/common-functions/tfplan-functions/docs/to_string.md
+++ b/common-functions/tfplan-functions/docs/to_string.md
@@ -1,0 +1,28 @@
+# to_string
+This function converts any Sentinel object including complex compositions of primitive types (string, int, float, and bool), null, undefined, lists, and maps to a string.
+
+## Sentinel Module
+This function is contained in the [tfplan-functions.sentinel](../tfplan-functions.sentinel) module.
+
+## Declaration
+`to_string = func(obj)`
+
+## Arguments
+* **obj**: a Sentinel object of any type
+
+## Common Functions Used
+This function calls itself recursively to support composite objects.
+
+## What It Returns
+This function returns a single string.
+
+## What It Prints
+This function does not print anything.
+
+## Examples
+This function is called by all of the filter functions in the tfplan-functions.sentinel module. Here is a typical example:
+```
+message = to_string(address) + " has " + to_string(attr) + " with value " +
+          to_string(v) + " that is not in the allowed list: " +
+          to_string(allowed)
+```

--- a/common-functions/tfplan-functions/tfplan-functions.sentinel
+++ b/common-functions/tfplan-functions/tfplan-functions.sentinel
@@ -1,0 +1,1071 @@
+# Common functions that use the tfplan/v2 import
+
+# The filter functions all accept a collection of resource changes, an attribute,
+# a value or a list of values, and a boolean, prtmsg, which can be true or false
+# and indicates whether the filter function should print violation messages.
+# The filter functions return a map consisting of 2 items:
+#   * "resources": a map consisting of resource changes that violate a condition
+#   * "messages":  a map of violation messages associated with the resources
+# Note that both the resources and messages collections are indexed by the
+# address of the resources, so they will have the same order and length.
+# The filter functions all call evaluate_attribute() to evaluate attributes
+# of resources even if nested deep within them.
+
+##### Imports #####
+import "tfplan/v2" as tfplan
+import "strings"
+import "types"
+
+##### Functions #####
+
+### find_resources ###
+# Find all resources of a specific type using the tfplan/v2 import.
+# Include resources that are not being permanently deleted.
+# Technically, this returns a map of resource changes.
+find_resources = func(type) {
+	resources = filter tfplan.resource_changes as address, rc {
+		rc.type is type and
+			rc.mode is "managed" and
+			(rc.change.actions contains "create" or rc.change.actions contains "update" or
+				rc.change.actions contains "read" or
+				(rc.change.actions contains "no-op" and
+					rc.change.after is not null))
+	}
+
+	return resources
+}
+
+### find_resources_by_provider ###
+# Find all resources for a specific provider using the tfplan/v2 import.
+# Include resources that are not being permanently deleted.
+# Technically, this returns a map of resource changes.
+# Terraform 0.12 and earlier set `rc.provider_name` to short text like "null";
+# but Terraform 0.13 and higher set it to something like
+# "registry.terraform.io/hashicorp/null".
+# You can pass in the long form or short form.
+find_resources_by_provider = func(provider) {
+	parsed_provider = strings.split(provider, "/")
+	segment_count = length(parsed_provider)
+	v = strings.split(tfplan.terraform_version, ".")
+	v_major = int(v[1])
+
+	# If v_major is 12, we know short form was passed to Sentinel
+	if v_major is 12 {
+		resources = filter tfplan.resource_changes as address, rc {
+			rc.provider_name is provider and
+				rc.mode is "managed" and
+				(rc.change.actions contains "create" or rc.change.actions contains "update" or
+					rc.change.actions contains "read" or
+					(rc.change.actions contains "no-op" and
+						rc.change.after is not null))
+		}
+	} else {
+		# v_major must be higher than 12 since v2 imports being used
+		# So, we know long form like "registry.terraform.io/hashicorp/null" given
+		if segment_count is 1 {
+			# Function was passed short form, so we want to reduce each occurence of
+			# rc.provider_name to its short form.
+			resources = filter tfplan.resource_changes as address, rc {
+				strings.split(rc.provider_name, "/")[2] is provider and
+					rc.mode is "managed" and
+					(rc.change.actions contains "create" or rc.change.actions contains "update" or
+						rc.change.actions contains "read" or
+						(rc.change.actions contains "no-op" and
+							rc.change.after is not null))
+			}
+		} else {
+			# Function was passed long form, so we use full rc.provider_name
+			resources = filter tfplan.resource_changes as address, rc {
+				rc.provider_name is provider and
+					rc.mode is "managed" and
+					(rc.change.actions contains "create" or rc.change.actions contains "update" or
+						rc.change.actions contains "read" or
+						(rc.change.actions contains "no-op" and
+							rc.change.after is not null))
+			}
+		} // end segment_count
+	} // end v_major
+
+	return resources
+}
+
+### find_datasources ###
+# Find all data sources of a specific type using the tfplan/v2 import.
+# Include data sources that are not being permanently deleted.
+# Technically, this returns a map of resource changes.
+find_datasources = func(type) {
+	datasources = filter tfplan.resource_changes as address, rc {
+		rc.type is type and
+			rc.mode is "data" and
+			(rc.change.actions contains "create" or
+				rc.change.actions contains "update" or
+				rc.change.actions contains "read" or
+				(rc.change.actions contains "no-op" and rc.change.after is not null))
+	}
+
+	return datasources
+}
+
+### find_datasources_by_provider ###
+# Find all data sources for a specific provider using the tfplan/v2 import.
+# Include data sources that are not being permanently deleted.
+# Technically, this returns a map of resource changes.
+# Terraform 0.12 and earlier set `rc.provider_name` to short text like "null";
+# but Terraform 0.13 and higher set it to something like
+# "registry.terraform.io/hashicorp/null".
+# You can pass in the long form or short form.
+find_datasources_by_provider = func(provider) {
+	parsed_provider = strings.split(provider, "/")
+	segment_count = length(parsed_provider)
+	v = strings.split(tfplan.terraform_version, ".")
+	v_major = int(v[1])
+
+	# If v_major is 12, we know short form was passed to Sentinel
+	if v_major is 12 {
+		datasources = filter tfplan.resource_changes as address, rc {
+			rc.provider_name is provider and
+				rc.mode is "data" and
+				(rc.change.actions contains "create" or rc.change.actions contains "update" or
+					rc.change.actions contains "read" or
+					(rc.change.actions contains "no-op" and
+						rc.change.after is not null))
+		}
+	} else {
+		# v_major must be higher than 12 since v2 imports being used
+		# So, we know long form like "registry.terraform.io/hashicorp/null" given
+		if segment_count is 1 {
+			# Function was passed short form, so we want to reduce each occurence of
+			# rc.provider_name to its short form.
+			datasources = filter tfplan.resource_changes as address, rc {
+				strings.split(rc.provider_name, "/")[2] is provider and
+					rc.mode is "data" and
+					(rc.change.actions contains "create" or rc.change.actions contains "update" or
+						rc.change.actions contains "read" or
+						(rc.change.actions contains "no-op" and
+							rc.change.after is not null))
+			}
+		} else {
+			# Function was passed long form, so we use full rc.provider_name
+			datasources = filter tfplan.resource_changes as address, rc {
+				rc.provider_name is provider and
+					rc.mode is "data" and
+					(rc.change.actions contains "create" or rc.change.actions contains "update" or
+						rc.change.actions contains "read" or
+						(rc.change.actions contains "no-op" and
+							rc.change.after is not null))
+			}
+		} // end segment_count
+	} // end v_major
+
+	return datasources
+}
+
+### find_resources_being_destroyed ###
+# Find all resources being destroyed but not recreated using the tfplan/v2 import.
+# Technically, this returns a map of resource changes.
+find_resources_being_destroyed = func() {
+	resources = filter tfplan.resource_changes as address, rc {
+		rc.mode is "managed" and
+			rc.change.actions contains "delete" and
+			not (rc.change.actions contains "create" or rc.change.actions contains "update")
+	}
+
+	return resources
+}
+
+### find_datasources_being_destroyed ###
+# Find all data sources being destroyed but not recreated using the tfplan/v2 import.
+# Technically, this returns a map of resource changes.
+find_datasources_being_destroyed = func() {
+	datasources = filter tfplan.resource_changes as address, rc {
+		rc.mode is "data" and
+			rc.change.actions contains "delete" and
+			not (rc.change.actions contains "create" or
+				rc.change.actions contains "update")
+	}
+
+	return datasources
+}
+
+### find_blocks ###
+# Find all blocks of a specific type from a resource using the tfplan/v2 import.
+# parent should be a single resource or block of a resource or a data source
+# or a block of a data source.
+# If parent is a resource, you can pass it in the form rc.change.after or just rc.
+# child should be a string representing a block of parent
+# that contains a list of objects.
+find_blocks = func(parent, child) {
+	# Use parent.change.after if it exists
+	if (types.type_of(parent) is "map" and
+		"change" in keys(parent)) and
+		(types.type_of(parent.change) is "map" and
+			"after" in keys(parent.change)) {
+		if types.type_of(parent.change.after[child] else null) is "list" {
+			return parent.change.after[child]
+		} else {
+			return []
+		}
+	} else {
+		if types.type_of(parent[child] else null) is "list" {
+			return parent[child]
+		} else {
+			return []
+		}
+	}
+}
+
+### to_string ###
+# Convert objects of unknown type to string
+# It is used to build messages added to the messages map returned by the
+# filter functions
+to_string = func(obj) {
+	case types.type_of(obj) {
+		when "string":
+			return obj
+		when "int", "float", "bool":
+			return string(obj)
+		when "null":
+			return "null"
+		when "undefined":
+			return "undefined"
+		when "list":
+			output = "["
+			lastIndex = length(obj) - 1
+			for obj as index, value {
+				if index < lastIndex {
+					output += to_string(value) + ", "
+				} else {
+					output += to_string(value)
+				}
+			}
+			output += "]"
+			return output
+		when "map":
+			output = "{"
+			theKeys = keys(obj)
+			lastIndex = length(theKeys) - 1
+			for theKeys as index, key {
+				if index < lastIndex {
+					output += to_string(key) + ": " + to_string(obj[key]) + ", "
+				} else {
+					output += to_string(key) + ": " + to_string(obj[key])
+				}
+			}
+			output += "}"
+			return output
+		else:
+			return ""
+	}
+}
+
+### evaluate_attribute ###
+# Evaluates the value of a resource's or block's attribute even if nested.
+# The resource should be derived by applying filters to tfplan.resource_changes.
+# It can be given in the initial call in the form rc.change.after or just rc.
+# If you want to evaluate previous values, pass `rc.change.before` instead of
+# `rc` since the function converts `rc` by itself to `rc.change.after`.
+# Indices of lists should be given as 0, 1, 2, and so on.
+# For example: boot_disk.0.initialize_params.0.image
+evaluate_attribute = func(r, attribute) {
+
+	# Split the attribute into a list, using "." as the separator
+	attributes = strings.split(attribute, ".")
+
+	# Convert numeric strings to integers for indices
+	if attributes[0] matches "^[0-9]+$" {
+		a = int(attributes[0])
+		# Make sure r is of type list
+		if types.type_of(r) is not "list" {
+			return undefined
+		}
+	} else {
+		a = attributes[0]
+	}
+
+	# Append the current attribute to the resource instance
+	if (types.type_of(r) is "map" and "change" in keys(r)) and
+		(types.type_of(r.change) is "map" and "after" in keys(r.change)) {
+		new_r = r.change.after[a] else null
+	} else {
+		new_r = r[a] else null
+	}
+
+	# Process based on length of attributes
+	# being greater than or equal to 1
+	if length(attributes) > 1 {
+
+		# Strip first element from attributes
+		attributes = attributes[1:length(attributes)]
+		attribute = strings.join(attributes, ".")
+
+		# Make recursive call
+		return evaluate_attribute(new_r, attribute)
+	} else {
+
+		# We reached the end of the attribute and can stop the
+		# recursive calls and return the value of the attribute
+		return new_r
+
+	}
+}
+
+### print_violations ###
+# Prints violations returned by any of the filter functions defined below.
+# This would normally only be called if the filter function had been called
+# with prtmsg set to false, which is sometimes done when processing resources
+# and their blocks.
+# If the result of a filter function is assigned to a map like violatingIRs,
+# then you should pass violatingIRs["message"] as the first argument.
+# The prefix argument is printed before the message of each resource.
+print_violations = func(messages, prefix) {
+	for messages as address, message {
+		print(prefix, message)
+	}
+	return true
+}
+
+### filter_attribute_not_in_list ###
+# Filter a list of resources to those with a specified
+# attribute (attr) that is not in a given list of allowed values (allowed).
+# Resources should be derived by applying filters to tfplan.resource_changes.
+# Set prtmsg to `true` (without quotes) if you want to print violation messages.
+# If you want to allow null, include "null" in the list (allowed).
+filter_attribute_not_in_list = func(resources, attr, allowed, prtmsg) {
+	violators = {}
+	messages = {}
+	for resources as address, rc {
+		# Evaluate the value (v) of the attribute
+		v = evaluate_attribute(rc, attr) else null
+		# Convert null to "null"
+		if v is null {
+			v = "null"
+		}
+		# Check if the value is not in the allowed list
+		if v not in allowed {
+			# Add the resource and a warning message to the violators list
+			message = to_string(address) + " has " + to_string(attr) + " with value " +
+				to_string(v) +
+				" that is not in the allowed list: " +
+				to_string(allowed)
+			violators[address] = rc
+			messages[address] = message
+			if prtmsg {
+				print(message)
+			}
+		} // end if
+	} // end for
+	return {"resources": violators, "messages": messages}
+}
+
+### filter_attribute_in_list ###
+# Filter a list of resources to those with a specified
+# attribute (attr) that is in a given list of forbidden values (forbidden).
+# Resources should be derived by applying filters to tfplan.resource_changes.
+# Set prtmsg to `true` (without quotes) if you want to print violation messages.
+# If you want to disallow null, include "null" in the list (forbidden).
+filter_attribute_in_list = func(resources, attr, forbidden, prtmsg) {
+	violators = {}
+	messages = {}
+	for resources as address, rc {
+		# Evaluate the value (v) of the attribute
+		v = evaluate_attribute(rc, attr) else null
+		# Check if the value is null
+		if v is null {
+			v = "null"
+		}
+		# Check if the value is in the forbidden list
+		if v in forbidden {
+			# Add the resource and a warning message to the violators list
+			message = to_string(address) + " has " + to_string(attr) + " with value " +
+				to_string(v) +
+				" that is in the forbidden list: " +
+				to_string(forbidden)
+			violators[address] = rc
+			messages[address] = message
+			if prtmsg {
+				print(message)
+			}
+		}
+	}
+	return {"resources": violators, "messages": messages}
+}
+
+### filter_attribute_not_contains_list ###
+# Filter a list of resources to those with a specified
+# attribute (attr) that does not contain a given list of required values (required).
+# Set prtmsg to `true` (without quotes) if you want to print violation messages.
+# Resources should be derived by applying filters to tfplan.resource_changes.
+filter_attribute_not_contains_list = func(resources, attr, required, prtmsg) {
+	violators = {}
+	messages = {}
+	for resources as address, rc {
+		# Evaluate the value (v) of the attribute
+		v = evaluate_attribute(rc, attr) else null
+		# Check if the value contains the desired allowed list
+		if v is null or
+			not (types.type_of(v) is "list" or types.type_of(v) is "map") {
+			# Add the resource and a warning message to the violators list
+			message = to_string(address) + " has " + to_string(attr) +
+				" that is missing, null, or is not a map or a list. " +
+				"It should have had these items: " +
+				to_string(required)
+			violators[address] = rc
+			messages[address] = message
+			if prtmsg {
+				print(message)
+			}
+		} else {
+			missing_values = []
+			for required as rv {
+				if v not contains rv {
+					append(missing_values, rv)
+				} // end if
+			} // end for required
+			if length(missing_values) > 0 {
+				# Build warning message when v is a map
+				message = to_string(address) + " has " + to_string(attr) + " " +
+					to_string(v) +
+					" that is missing the required items " +
+					to_string(missing_values) +
+					" from the list: " +
+					to_string(required)
+				# Add the resource and warning message to the violators list
+				violators[address] = rc
+				messages[address] = message
+				if prtmsg {
+					print(message)
+				}
+			} // end length(missing_values)
+		} // end else v not null
+	} // end for
+	return {"resources": violators, "messages": messages}
+}
+
+### filter_attribute_contains_items_from_list ###
+# Filter a list of resources to those with a specified
+# attribute (attr) that contains any items from a given list of
+# forbidden values (forbidden).
+# Resources should be derived by applying filters to tfplan.resource_changes.
+# Set prtmsg to `true` (without quotes) if you want to print violation messages.
+# If you want to disallow null, include "null" in the list (forbidden).
+filter_attribute_contains_items_from_list = func(resources, attr, forbidden, prtmsg) {
+	violators = {}
+	messages = {}
+	for resources as address, rc {
+		# Evaluate the value (v) of the attribute
+		v = evaluate_attribute(rc, attr) else null
+		# Check if the value contains the desired allowed list
+		if not (types.type_of(v) is "list" or types.type_of(v) is "map" or
+			types.type_of(v) is "null") {
+			# Add the resource and a warning message to the violators list
+			message = to_string(address) + " has " + to_string(attr) + " " +
+				to_string(v) +
+				" that is not a map, a list, or null"
+			violators[address] = rc
+			messages[address] = message
+			if prtmsg {
+				print(message)
+			}
+		} else if v is null {
+			if "null" in forbidden {
+				# Add the resource and a warning message to the violators list
+				message = to_string(address) + " has " + to_string(attr) +
+					" with value null from the forbidden list: " +
+					to_string(forbidden)
+				violators[address] = rc
+				messages[address] = message
+				if prtmsg {
+					print(message)
+				}
+			}
+		} else {
+			forbidden_values = []
+			for forbidden as fv {
+				if v contains fv {
+					append(forbidden_values, fv)
+				} // end if
+			} // end for forbidden
+			if length(forbidden_values) > 0 {
+				# Build warning message when v is a list
+				message = to_string(address) + " has " + to_string(attr) + " " +
+					to_string(v) +
+					" that has items " +
+					to_string(forbidden_values) +
+					" from the forbidden list: " +
+					to_string(forbidden)
+				# Add the resource and a warning message to the violators list
+				violators[address] = rc
+				messages[address] = message
+				if prtmsg {
+					print(message)
+				}
+			} // end length(forbidden_values)
+		} // end v not null
+	} // end for
+	return {"resources": violators, "messages": messages}
+}
+
+### filter_attribute_contains_items_not_in_list ###
+# Filter a list of resources to those with a specified
+# attribute (attr) that contains items not in a given list of allowed values.
+# Resources should be derived by applying filters to tfplan.resource_changes.
+# Set prtmsg to `true` (without quotes) if you want to print violation messages.
+# If you want to allow null, include "null" in the list (allowed).
+filter_attribute_contains_items_not_in_list = func(resources, attr, allowed, prtmsg) {
+	violators = {}
+	messages = {}
+	for resources as address, rc {
+		# Evaluate the value (vals) of the attribute
+		vals = evaluate_attribute(rc, attr) else null
+		# Check if the value contains items not in allowed list
+		if not (types.type_of(vals) is "list" or types.type_of(vals) is "map" or
+			types.type_of(vals) is "null") {
+			# Add the resource and a warning message to the violators list
+			message = to_string(address) + " has " + to_string(attr) + " " +
+				to_string(vals) +
+				" that is not a map, a list, or null"
+			violators[address] = rc
+			messages[address] = message
+			if prtmsg {
+				print(message)
+			}
+		} else if vals is null {
+			if "null" not in allowed {
+				# Add the resource and a warning message to the violators list
+				message = to_string(address) + " has " + to_string(attr) +
+					" with value null " +
+					"that is not in the allowed list: " +
+					to_string(allowed)
+				violators[address] = rc
+				messages[address] = message
+				if prtmsg {
+					print(message)
+				}
+			}
+		} else {
+			forbidden_values = []
+			for vals as v {
+				if v not in allowed {
+					append(forbidden_values, v)
+				} // end if v not allowed
+			} // end for vals
+			if length(forbidden_values) > 0 {
+				# Build warning message when vals is a map
+				message = to_string(address) + " has " + to_string(attr) + " " +
+					to_string(vals) +
+					" with items " +
+					to_string(forbidden_values) +
+					" that are not in the allowed list: " +
+					to_string(allowed)
+				# Add the resource and a warning message to the violators list
+				violators[address] = rc
+				messages[address] = message
+				if prtmsg {
+					print(message)
+				}
+			} // end length(forbidden_values)
+		} // end if null
+	} // end for
+	return {"resources": violators, "messages": messages}
+}
+
+### filter_attribute_is_not_value ###
+# Filter a list of resources to those with a specified
+# attribute (attr) that does not have a given value.
+# Resources should be derived by applying filters to tfplan.resource_changes.
+# Set prtmsg to `true` (without quotes) if you want to print violation messages.
+filter_attribute_is_not_value = func(resources, attr, value, prtmsg) {
+	violators = {}
+	messages = {}
+	for resources as address, rc {
+		v = evaluate_attribute(rc, attr) else null
+		if v is null {
+			# Add the resource and a warning message to the violators list
+			message = to_string(address) + " has " + to_string(attr) +
+				" that is null or undefined. " +
+				"It is supposed to be " +
+				to_string(value)
+			violators[address] = rc
+			messages[address] = message
+			if prtmsg {
+				print(message)
+			}
+		} else if v is not value {
+			# Add the resource and a warning message to the violators list
+			message = to_string(address) + " has " + to_string(attr) + " with value " +
+				to_string(v) +
+				" that is not equal to " +
+				to_string(value)
+			violators[address] = rc
+			messages[address] = message
+			if prtmsg {
+				print(message)
+			}
+		}
+	}
+	return {"resources": violators, "messages": messages}
+}
+
+### filter_attribute_was_not_value ###
+# Filter a list of resources to those with a specified
+# attribute (attr) that did not have a given value.
+# Resources should be derived by applying filters to tfplan.resource_changes.
+# Set prtmsg to `true` (without quotes) if you want to print violation messages.
+# If you want to match null, set value to "null".
+# Note that it this function passes `rc.change.before` instead of `rc`
+# to the evaluate_attribute() function which converts `rc` to `rc.change.after`.
+filter_attribute_was_not_value = func(resources, attr, value, prtmsg) {
+	violators = {}
+	messages = {}
+	for resources as address, rc {
+		v = evaluate_attribute(rc.change.before, attr) else null
+		if v is null {
+			# Add the resource and a warning message to the violators list
+			message = to_string(address) + " had " + to_string(attr) +
+				" that was null or undefined. " +
+				"It was supposed to be " +
+				to_string(value)
+			violators[address] = rc
+			messages[address] = message
+			if prtmsg {
+				print(message)
+			}
+		} else if v is not value {
+			# Add the resource and a warning message to the violators list
+			message = to_string(address) + " had " + to_string(attr) + " with value " +
+				to_string(v) +
+				" that was not equal to " +
+				to_string(value)
+			violators[address] = rc
+			messages[address] = message
+			if prtmsg {
+				print(message)
+			}
+		}
+	}
+	return {"resources": violators, "messages": messages}
+}
+
+### filter_attribute_is_value ###
+# Filter a list of resources to those with a specified
+# attribute (attr) that has a given value.
+# Resources should be derived by applying filters to tfplan.resource_changes.
+# Set prtmsg to `true` (without quotes) if you want to print violation messages.
+# If you want to match null, set value to "null".
+filter_attribute_is_value = func(resources, attr, value, prtmsg) {
+	violators = {}
+	messages = {}
+	for resources as address, rc {
+		v = evaluate_attribute(rc, attr) else null
+		if v is null {
+			v = "null"
+		}
+		if v is value {
+			# Add the resource and a warning message to the violators list
+			message = to_string(address) + " has " + to_string(attr) + " with value " +
+				to_string(v) +
+				" that is not allowed."
+			violators[address] = rc
+			messages[address] = message
+			if prtmsg {
+				print(message)
+			}
+		}
+	}
+	return {"resources": violators, "messages": messages}
+}
+
+### filter_attribute_was_value ###
+# Filter a list of resources to those with a specified
+# attribute (attr) that had a given value.
+# Resources should be derived by applying filters to tfplan.resource_changes.
+# Set prtmsg to `true` (without quotes) if you want to print violation messages.
+# If you want to match null, set value to "null".
+# Note that it this function passes `rc.change.before` instead of `rc`
+# to the evaluate_attribute() function which converts `rc` to `rc.change.after`.
+filter_attribute_was_value = func(resources, attr, value, prtmsg) {
+	violators = {}
+	messages = {}
+	for resources as address, rc {
+		v = evaluate_attribute(rc.change.before, attr) else null
+		if v is null {
+			v = "null"
+		}
+		if v is value {
+			# Add the resource and a warning message to the violators list
+			message = to_string(address) + " had " + to_string(attr) + " with value " +
+				to_string(v) +
+				" that was not allowed."
+			violators[address] = rc
+			messages[address] = message
+			if prtmsg {
+				print(message)
+			}
+		}
+	}
+	return {"resources": violators, "messages": messages}
+}
+
+### filter_attribute_greater_than_value ###
+# Filter a list of resources to those with a specified
+# attribute (attr) that is greater than a given numeric value.
+# Resources should be derived by applying filters to tfplan.resource_changes.
+# Set prtmsg to `true` (without quotes) if you want to print violation messages.
+filter_attribute_greater_than_value = func(resources, attr, value, prtmsg) {
+	violators = {}
+	messages = {}
+	for resources as address, rc {
+		v = evaluate_attribute(rc, attr) else null
+		if float(v) else null is null {
+			# Add the resource and a warning message to the violators list
+			message = to_string(address) + " has " + to_string(attr) +
+				" that is null or undefined. " +
+				"It is supposed to be less " +
+				"than or equal to " +
+				to_string(value)
+			violators[address] = rc
+			messages[address] = message
+			if prtmsg {
+				print(message)
+			}
+		} else if float(v) > value {
+			# Add the resource and a warning message to the violators list
+			message = to_string(address) + " has " + to_string(attr) + " with value " +
+				to_string(v) +
+				" that is greater than " +
+				to_string(value)
+			violators[address] = rc
+			messages[address] = message
+			if prtmsg {
+				print(message)
+			}
+		}
+	}
+	return {"resources": violators, "messages": messages}
+}
+
+### filter_attribute_greater_than_equal_to_value ###
+# Filter a list of resources to those with a specified
+# attribute (attr) that is greater than a given numeric value.
+# Resources should be derived by applying filters to tfplan.resource_changes.
+# Set prtmsg to `true` (without quotes) if you want to print violation messages.
+filter_attribute_greater_than_equal_to_value = func(resources, attr, value, prtmsg) {
+	violators = {}
+	messages = {}
+	for resources as address, rc {
+		v = evaluate_attribute(rc, attr) else null
+		if float(v) else null is null {
+			# Add the resource and a warning message to the violators list
+			message = to_string(address) + " has " + to_string(attr) +
+				" that is null or undefined. " +
+				"It is supposed to be less " +
+				"than " +
+				to_string(value)
+			violators[address] = rc
+			messages[address] = message
+			if prtmsg {
+				print(message)
+			}
+		} else if float(v) >= value {
+			# Add the resource and a warning message to the violators list
+			message = to_string(address) + " has " + to_string(attr) + " with value " +
+				to_string(v) +
+				" that is greater than or equal to " +
+				to_string(value)
+			violators[address] = rc
+			messages[address] = message
+			if prtmsg {
+				print(message)
+			}
+		}
+	}
+	return {"resources": violators, "messages": messages}
+}
+
+### filter_attribute_less_than_value ###
+# Filter a list of resources to those with a specified
+# attribute (attr) that is less than a given numeric value.
+# Resources should be derived by applying filters to tfplan.resource_changes.
+# Set prtmsg to `true` (without quotes) if you want to print violation messages.
+filter_attribute_less_than_value = func(resources, attr, value, prtmsg) {
+	violators = {}
+	messages = {}
+	for resources as address, rc {
+		v = evaluate_attribute(rc, attr) else null
+		if float(v) else null is null {
+			# Add the resource and a warning message to the violators list
+			message = to_string(address) + " has " + to_string(attr) +
+				" that is null or undefined. " +
+				"It is supposed to be greater " +
+				"than or equal to " +
+				to_string(value)
+			violators[address] = rc
+			messages[address] = message
+			if prtmsg {
+				print(message)
+			}
+		} else if float(v) < value {
+			# Add the resource and a warning message to the violators list
+			message = to_string(address) + " has " + to_string(attr) + " with value " +
+				to_string(v) +
+				" that is less than " +
+				to_string(value)
+			violators[address] = rc
+			messages[address] = message
+			if prtmsg {
+				print(message)
+			}
+		}
+	}
+	return {"resources": violators, "messages": messages}
+}
+
+### filter_attribute_less_than_equal_to_value ###
+# Filter a list of resources to those with a specified
+# attribute (attr) that is less than a given numeric value.
+# Resources should be derived by applying filters to tfplan.resource_changes.
+# Set prtmsg to `true` (without quotes) if you want to print violation messages.
+filter_attribute_less_than_equal_to_value = func(resources, attr, value, prtmsg) {
+	violators = {}
+	messages = {}
+	for resources as address, rc {
+		v = evaluate_attribute(rc, attr) else null
+		if float(v) else null is null {
+			# Add the resource and a warning message to the violators list
+			message = to_string(address) + " has " + to_string(attr) +
+				" that is null or undefined. " +
+				"It is supposed to be greater " +
+				"than " +
+				to_string(value)
+			violators[address] = rc
+			messages[address] = message
+			if prtmsg {
+				print(message)
+			}
+		} else if float(v) <= value {
+			# Add the resource and a warning message to the violators list
+			message = to_string(address) + " has " + to_string(attr) + " with value " +
+				to_string(v) +
+				" that is less than or equal to " +
+				to_string(value)
+			violators[address] = rc
+			messages[address] = message
+			if prtmsg {
+				print(message)
+			}
+		}
+	}
+	return {"resources": violators, "messages": messages}
+}
+
+### filter_attribute_does_not_match_regex ###
+# Filter a list of resources to those with a specified
+# attribute (attr) that does not match a regular expression (expr).
+# Resources should be derived by applying filters to tfplan.resource_changes.
+# Set prtmsg to `true` (without quotes) if you want to print violation messages.
+# If you want to allow null, set `expr` to "(<regex>|null)".
+filter_attribute_does_not_match_regex = func(resources, attr, expr, prtmsg) {
+	violators = {}
+	messages = {}
+	for resources as address, rc {
+		v = evaluate_attribute(rc, attr) else null
+		if v is null {
+			v = "null"
+		}
+		if v not matches expr {
+			# Add the resource and a warning message to the violators list
+			message = to_string(address) + " has " + to_string(attr) + " with value " +
+				to_string(v) +
+				" that does not match the regex " +
+				to_string(expr)
+			violators[address] = rc
+			messages[address] = message
+			if prtmsg {
+				print(message)
+			}
+		}
+	}
+	return {"resources": violators, "messages": messages}
+}
+
+### filter_attribute_matches_regex ###
+# Filter a list of resources to those with a specified
+# attribute (attr) that matches a regular expression (expr).
+# Resources should be derived by applying filters to tfplan.resource_changes.
+# Set prtmsg to `true` (without quotes) if you want to print violation messages.
+# If you want to match null, set expr to "null".
+filter_attribute_matches_regex = func(resources, attr, expr, prtmsg) {
+	violators = {}
+	messages = {}
+	for resources as address, rc {
+		v = evaluate_attribute(rc, attr) else null
+		if v is null {
+			v = "null"
+		}
+		if v matches expr {
+			# Add the resource and a warning message to the violators list
+			message = to_string(address) + " has " + to_string(attr) + " with value " +
+				to_string(v) +
+				" that matches the regex " +
+				to_string(expr)
+			violators[address] = rc
+			messages[address] = message
+			if prtmsg {
+				print(message)
+			}
+		}
+	}
+	return {"resources": violators, "messages": messages}
+}
+
+### filter_attribute_does_not_have_prefix ###
+# Filter a list of resources to those with a specified
+# attribute (attr) that does not have a given prefix.
+# Resources should be derived by applying filters to tfplan.resource_changes.
+# Set prtmsg to `true` (without quotes) if you want to print violation messages.
+filter_attribute_does_not_have_prefix = func(resources, attr, prefix, prtmsg) {
+	violators = {}
+	messages = {}
+	for resources as address, rc {
+		v = evaluate_attribute(rc, attr) else null
+		if v is null {
+			# Add the resource and a warning message to the violators list
+			message = to_string(address) + " has " + to_string(attr) +
+				" that is null or undefined. " +
+				"It must have a value that " +
+				"starts with " +
+				to_string(prefix)
+			violators[address] = rc
+			messages[address] = message
+			if prtmsg {
+				print(message)
+			}
+		} else if not strings.has_prefix(v, prefix) {
+			# Add the resource and a warning message to the violators list
+			message = to_string(address) + " has " + to_string(attr) + " with value " +
+				to_string(v) +
+				" that does not have the prefix " +
+				to_string(prefix)
+			violators[address] = rc
+			messages[address] = message
+			if prtmsg {
+				print(message)
+			}
+		}
+	}
+	return {"resources": violators, "messages": messages}
+}
+
+### filter_attribute_has_prefix ###
+# Filter a list of resources to those with a specified
+# attribute (attr) that has a given prefix.
+# Resources should be derived by applying filters to tfplan.resource_changes.
+# Set prtmsg to `true` (without quotes) if you want to print violation messages.
+filter_attribute_has_prefix = func(resources, attr, prefix, prtmsg) {
+	violators = {}
+	messages = {}
+	for resources as address, rc {
+		v = evaluate_attribute(rc, attr) else null
+		if v is null {
+			# Add the resource and a warning message to the violators list
+			message = to_string(address) + " has " + to_string(attr) +
+				" that is null or undefined. " +
+				"It must have a value that " +
+				"does not start with " +
+				to_string(prefix)
+			violators[address] = rc
+			messages[address] = message
+			if prtmsg {
+				print(message)
+			}
+		} else if strings.has_prefix(v, prefix) {
+			# Add the resource and a warning message to the violators list
+			message = to_string(address) + " has " + to_string(attr) + " with value " +
+				to_string(v) +
+				" that has the prefix " +
+				to_string(prefix)
+			violators[address] = rc
+			messages[address] = message
+			if prtmsg {
+				print(message)
+			}
+		}
+	}
+	return {"resources": violators, "messages": messages}
+}
+
+### filter_attribute_does_not_have_suffix ###
+# Filter a list of resources to those with a specified
+# attribute (attr) that does not have a given suffix.
+# Resources should be derived by applying filters to tfplan.resource_changes.
+# Set prtmsg to `true` (without quotes) if you want to print violation messages.
+filter_attribute_does_not_have_suffix = func(resources, attr, suffix, prtmsg) {
+	violators = {}
+	messages = {}
+	for resources as address, rc {
+		v = evaluate_attribute(rc, attr) else null
+		if v is null {
+			# Add the resource and a warning message to the violators list
+			message = to_string(address) + " has " + to_string(attr) +
+				" that is null or undefined. " +
+				"It must have a value that " +
+				"ends with " +
+				to_string(prefix)
+			violators[address] = rc
+			messages[address] = message
+			if prtmsg {
+				print(message)
+			}
+		} else if not strings.has_suffix(v, suffix) {
+			# Add the resource and a warning message to the violators list
+			message = to_string(address) + " has " + to_string(attr) + " with value " +
+				to_string(v) +
+				" that does not have the suffix " +
+				to_string(suffix)
+			violators[address] = rc
+			messages[address] = message
+			if prtmsg {
+				print(message)
+			}
+		}
+	}
+	return {"resources": violators, "messages": messages}
+}
+
+### filter_attribute_has_suffix ###
+# Filter a list of resources to those with a specified
+# attribute (attr) that has a given suffix.
+# Resources should be derived by applying filters to tfplan.resource_changes.
+# Set prtmsg to `true` (without quotes) if you want to print violation messages.
+filter_attribute_has_suffix = func(resources, attr, suffix, prtmsg) {
+	violators = {}
+	messages = {}
+	for resources as address, rc {
+		v = evaluate_attribute(rc, attr) else null
+		if v is null {
+			# Add the resource and a warning message to the violators list
+			message = to_string(address) + " has " + to_string(attr) +
+				" that is null or undefined. " +
+				"It must have a value that " +
+				"does not end with " +
+				to_string(suffix)
+			violators[address] = rc
+			messages[address] = message
+			if prtmsg {
+				print(message)
+			}
+		} else if strings.has_suffix(v, suffix) {
+			# Add the resource and a warning message to the violators list
+			message = to_string(address) + " has " + to_string(attr) + " with value " +
+				to_string(v) +
+				" that has the suffix " +
+				to_string(suffix)
+			violators[address] = rc
+			messages[address] = message
+			if prtmsg {
+				print(message)
+			}
+		}
+	}
+	return {"resources": violators, "messages": messages}
+}

--- a/common-functions/tfrun-functions/docs/limit_cost_and_percentage_increase.md
+++ b/common-functions/tfrun-functions/docs/limit_cost_and_percentage_increase.md
@@ -1,0 +1,32 @@
+# limit_cost_and_percentage_increase
+This function validates that the proposed monthly cost from the [cost estimates](https://www.terraform.io/docs/cloud/cost-estimation/index.html) of a plan done against a workspace is less than a given limit which is given in US dollars and that the percentage increase of the monthly cost is less than a given maximum percentage.
+
+## Sentinel Module
+This function is contained in the [tfrun-functions.sentinel](../tfrun-functions.sentinel) module.
+
+## Declaration
+`limit_cost_and_percentage_increase = func(limit, max_percent)`
+
+## Arguments
+* **limit**: the upper limit on the allowed estimated monthly costs (in US dollars) for the resources provisioned in the workspace, given as a [decimal](https://docs.hashicorp.com/sentinel/imports/decimal/).
+* **max_percent**: the upper limit on the percentage increase of the estimated monthly costs compared to the current monthly cost (if available), also given as a decimal.
+
+## Common Functions Used
+None
+
+## What It Returns
+This function returns `true` if the estimated monthly costs of the workspace are under `limit` and the percentage increase of those costs is less than `max_percent` or if no cost estimates were available. Otherwise, it returns `false`.
+
+## What It Prints
+This function prints messages indicating whether or not the estimated monthly costs are allowed or not. Additionally, if no cost estimates are available, it prints a message to indicate that.
+
+## Examples
+Here is an example of calling this function, assuming that the tfrun-functions.sentinel file that contains it has been imported with the alias `run`:
+```
+limit = decimal.new(1000)
+max_percent = decimal.new(10.0)
+cost_validated = run.limit_cost_and_percentage_increase(limit, max_percent)
+```
+Note that any policy calling this function must also import the standard decimal import with `import "decimal"`.
+
+This function is used by the cloud agnostic policy [limit-cost-and-percentage-increase.sentinel](../../../cloud-agnostic/limit-cost-and-percentage-increase.sentinel).

--- a/common-functions/tfrun-functions/docs/limit_cost_by_workspace_name.md
+++ b/common-functions/tfrun-functions/docs/limit_cost_by_workspace_name.md
@@ -1,0 +1,36 @@
+# limit_cost_by_workspace_name
+This function validates that the proposed monthly cost from the [cost estimates](https://www.terraform.io/docs/cloud/cost-estimation/index.html) of a plan done against a workspace is less than a given limit (given in US dollars). The limit is determined from a map that associates workspace names with different limits using regex matching.
+
+The idea is that you might set different limits for Dev, QA, and Production workspaces.
+
+## Sentinel Module
+This function is contained in the [tfrun-functions.sentinel](../tfrun-functions.sentinel) module.
+
+## Declaration
+`limit_cost_by_workspace_name = func(limits)`
+
+## Arguments
+* **limits**: a map associating strings (the keys of the map) with different upper limits (the values of the map) for the allowed estimated monthly costs (in US dollars) for the resources provisioned in the workspace. The strings are treated as workspace name prefixes and suffixes. In other words, the limit associated with the string "dev" will be applied to workspaces whose names start with "dev-" or end with "-dev". The limits assigned to each string in the map must be given as [decimals](https://docs.hashicorp.com/sentinel/imports/decimal/). Of course, you must coordinate the naming of your workspaces with the keys of the `limits` map.
+
+## Common Functions Used
+None
+
+## What It Returns
+This function returns `true` if the estimated monthly cost of the workspace is under the limit in the `limits` map that corresponds to the workspace name or if no cost estimates were available. Otherwise, it returns `false`. Note that if a workspace name does not match any of the keys in the `limits` map, the function will return `false` and probably cause the policy that called it to fail.
+
+## What It Prints
+This function prints messages indicating whether or not the estimated monthly costs are under the limit in the `limits` map that corresponds to the workspace name. Additionally, if no cost estimates are available or if the `limits` map does not contain a key that matches the workspace name, it prints a message to indicate that.
+
+## Examples
+Here is an example of calling this function, assuming that the tfrun-functions.sentinel file that contains it has been imported with the alias `run`:
+```
+limits = {
+  "dev": decimal.new(200),
+  "qa": decimal.new(500),
+  "prod": decimal.new(1000),
+}
+cost_validated = run.limit_cost_by_workspace_name(limits)
+```
+Note that any policy calling this function must also import the standard decimal import with `import "decimal"`.
+
+This function is used by the cloud agnostic policy [limit-cost-by-workspace-name.sentinel](../../../cloud-agnostic/limit-cost-by-workspace-name.sentinel).

--- a/common-functions/tfrun-functions/docs/limit_proposed_monthly_cost.md
+++ b/common-functions/tfrun-functions/docs/limit_proposed_monthly_cost.md
@@ -1,0 +1,30 @@
+# limit_proposed_monthly_cost
+This function validates that the proposed monthly cost from the [cost estimates](https://www.terraform.io/docs/cloud/cost-estimation/index.html) of a plan done against a workspace is less than a given limit which is given in US dollars.
+
+## Sentinel Module
+This function is contained in the [tfrun-functions.sentinel](../tfrun-functions.sentinel) module.
+
+## Declaration
+`limit_proposed_monthly_cost = func(limit)`
+
+## Arguments
+* **limit**: the upper limit on the allowed estimated monthly cost (in US dollars) for the resources provisioned in the workspace, given as a [decimal](https://docs.hashicorp.com/sentinel/imports/decimal/).
+
+## Common Functions Used
+None
+
+## What It Returns
+This function returns `true` if the estimated monthly cost of the workspace is less than or equal to `limit` or if no cost estimates were available. Otherwise, it returns `false`.
+
+## What It Prints
+This function prints messages indicating whether or not the estimated monthly cost is less than or equal to the limit. Additionally, if no cost estimates are available, it prints a message to indicate that.
+
+## Examples
+Here is an example of calling this function, assuming that the tfrun-functions.sentinel file that contains it has been imported with the alias `run`:
+```
+limit = decimal.new(1000)
+cost_validated = run.limit_proposed_monthly_cost(limit)
+```
+Note that any policy calling this function must also import the standard decimal import with `import "decimal"`.
+
+This function is used by the cloud agnostic policy [limit-proposed-monthly-cost.sentinel](../../../cloud-agnostic/limit-proposed-monthly-cost.sentinel).

--- a/common-functions/tfrun-functions/tfrun-functions.sentinel
+++ b/common-functions/tfrun-functions/tfrun-functions.sentinel
@@ -1,0 +1,141 @@
+# Common functions that use the tfrun import
+
+##### Imports #####
+import "tfrun"
+import "decimal"
+
+##### Functions #####
+
+### limit_proposed_monthly_cost ###
+# Validate that the proposed monthly cost is less than the limit
+limit_proposed_monthly_cost = func(limit) {
+
+	# Check whether cost estimate is available
+	# It should be for Terraform 0.12.x
+	# It should not be for Terraform 0.11.x
+	if tfrun.cost_estimate else null is null {
+		print("No cost estimates available")
+		# Allow the policy to pass
+		return true
+	}
+
+	# Determine proposed monthly cost
+	proposed_cost = decimal.new(tfrun.cost_estimate.proposed_monthly_cost)
+
+	# Compare proposed monthly cost to the limit
+	if proposed_cost.lte(limit) {
+		print("Proposed monthly cost", proposed_cost.string,
+			"is under the limit:", limit.string)
+		return true
+	} else {
+		print("Proposed monthly cost", proposed_cost.string,
+			"is over the limit:", limit.string)
+		return false
+	}
+}
+
+### limit_cost_and_percentage_increase ###
+# Validate that the proposed cost is less than the given limit and
+# that the percentage increase in the monthly cost
+# is less than a given percentage
+limit_cost_and_percentage_increase = func(limit, max_percent) {
+
+	validated = true
+
+	# Check whether cost estimate is available
+	# It should be for Terraform 0.12.x
+	# It should not be for Terraform 0.11.x
+	if tfrun.cost_estimate else null is null {
+		print("No cost estimates available")
+		# Allow the policy to pass
+		return true
+	}
+
+	# Determine cost data
+	prior_cost = decimal.new(tfrun.cost_estimate.prior_monthly_cost)
+	proposed_cost = decimal.new(tfrun.cost_estimate.proposed_monthly_cost)
+	increase_in_cost = decimal.new(tfrun.cost_estimate.delta_monthly_cost)
+
+	# Compare proposed monthly cost to the limit
+	if proposed_cost.gt(limit) {
+		print("Proposed monthly cost", proposed_cost.string,
+			"is over the limit:", limit.string)
+		validated = false
+	}
+
+	# If prior_cost is not 0.0, compare percentage increase in monthly cost
+	# to max_percent
+	if prior_cost.is_not(0.0) {
+		percentage_change = increase_in_cost.divide(prior_cost).multiply(100)
+		if decimal.new(percentage_change).gt(max_percent) {
+			print("Proposed percentage increase", percentage_change.float,
+				"is over the max percentage change:", max_percent.float)
+			validated = false
+		} else {
+			print("Proposed percentage increase", percentage_change.float,
+				"is under the max percentage change:", max_percent.float)
+		}
+	}
+
+	return validated
+
+}
+
+### limit_cost_by_workspace_name ###
+# Validate that the proposed monthly cost is less than the limit
+# This accepts a map, limits, whose keys should be strings like
+# "dev", "qa", or "prod" and whose values should be expressions like
+# decimal.new(200) (which indicates a monthly limit of $200).
+# The keys are treated as allowed workspace name prefixes and suffixes.
+# If a workspace does not have one of the keys as a prefix or suffix, it will
+# fail the policy.
+limit_cost_by_workspace_name = func(limits) {
+
+	# Check whether cost estimate is available
+	# It should be for Terraform 0.12.x
+	# It should not be for Terraform 0.11.x
+	if tfrun.cost_estimate else null is null {
+		print("No cost estimates available")
+		# Allow the policy to pass
+		return true
+	}
+
+	# Get workspace name
+	workspace_name = tfrun.workspace.name
+
+	# Iterate over the limits map to determine limit
+	the_limit = decimal.new(0)
+	matching_name_found = false
+	for limits as name, limit {
+		if workspace_name matches "(.+)-" + name + "$" or
+			workspace_name matches "^" + name + "-(.+)$" {
+			the_limit = limits[name]
+			matching_name_found = true
+			break
+		}
+	}
+
+	# Print message if workspace name did not match any keys
+	if matching_name_found is false {
+		print("The current workspace", workspace_name,
+			"is not allowed because no cost limits are associated with a",
+			"regular expression matching its name.")
+		return false
+	}
+
+	# Determine proposed monthly cost
+	proposed_cost = decimal.new(tfrun.cost_estimate.proposed_monthly_cost)
+
+	# Compare proposed monthly cost to the limit
+	if proposed_cost.lte(the_limit) {
+		print("Proposed monthly cost", proposed_cost.string,
+			"of workspace", workspace_name,
+			"is under the limit:", the_limit.string)
+		return true
+	} else {
+		print("Proposed monthly cost", proposed_cost.string,
+			"of workspace", workspace_name,
+			"is over the limit:", the_limit.string)
+		return false
+	}
+}

--- a/common-functions/tfstate-functions/docs/evaluate_attribute.md
+++ b/common-functions/tfstate-functions/docs/evaluate_attribute.md
@@ -1,0 +1,29 @@
+# evaluate_attribute
+This function evaluates the value of an attribute within a resource, data source, or block. The attribute can be deeply nested.
+
+## Sentinel Module
+This function is contained in the [tfstate-functions.sentinel](../tfstate-functions.sentinel) module.
+
+## Declaration
+`evaluate_attribute = func(r, attribute)`
+
+## Arguments
+* **r**: a single resource or block containing an attribute whose value you want to determine.
+* **attribute**: a string giving the attribute. If the attribute is nested, the various blocks containing it should be delimited with periods (`.`). Indices of lists should not include brackets and should start with 0. So, you would use `boot_disk.0.initialize_params.0.image` rather than `boot_disk[0].initialize_params[0].image`. If `r` represents a block, then `attribute` should be specified relative to that block.
+
+In practice, this function is only called by the filter functions, so the specification of the `attribute` parameter will be done when calling them.
+
+## Common Functions Used
+This function calls itself recursively to support nested attributes of resources and blocks.
+
+## What It Returns
+This function returns the value of the attribute of the resource or block. The type will vary depending on what kind of attribute is evaluated.
+
+## What It Prints
+This function does not print anything.
+
+## Examples
+This function is called by all of the filter functions in the tfstate-functions.sentinel module. Here is a typical example:
+```
+v = evaluate_attribute(r, attr) else null
+```

--- a/common-functions/tfstate-functions/docs/filter_attribute_contains_items_from_list.md
+++ b/common-functions/tfstate-functions/docs/filter_attribute_contains_items_from_list.md
@@ -1,0 +1,30 @@
+# filter_attribute_contains_items_from_list
+This function filters a collection of resources, data sources, or blocks to those with an attribute that contains any members of a given list. A policy would call it when it does not want the attribute to contain any members of the list.
+
+## Sentinel Module
+This function is contained in the [tfstate-functions.sentinel](../tfstate-functions.sentinel) module.
+
+## Declaration
+`filter_attribute_contains_items_from_list = func(resources, attr, forbidden, prtmsg)`
+
+## Arguments
+* **resources**: a map of resources derived from [`tfstate.resources`](https://www.terraform.io/docs/cloud/sentinel/import/tfstate-v2.html#the-resources-collection) or a list of blocks returned by the `find_blocks` function.
+* **attr**: the name of a resource attribute given as a string that should not contain any items in a given list. The attribute should be a list or a map. If the attribute is nested, the various blocks containing it should be delimited with periods (`.`). Indices of lists should not include brackets and should start with 0. So, you would use `boot_disk.0.initialize_params` rather than `boot_disk[0].initialize_params`.
+* **forbidden**: a list of values the attribute should not contain. If you want to disallow null, include "null" in the list.
+* **prtmsg**: a boolean indicating whether violation messages should be printed (if `true`) or not (if `false`).
+
+## Common Functions Used
+This function calls the [evaluate_attribute](./evaluate_attribute.md) and the [to_string](./to_string.md) functions.
+
+## What It Returns
+This function returns a map with two maps, `resources` and `messages`, both of which are indexed by the complete [addresses](https://www.terraform.io/docs/internals/resource-addressing.html) of the resources, data sources, or blocks that meet the condition of the filter function. The `resources` map contains the actual resource instances for which the attribute (`attr`) contains any items of the list (`forbidden`) while the `messages` map contains the violation messages associated with those instances.
+
+## What It Prints
+This function prints the violation messages if the parameter, `prtmsg`, was set to `true`. Otherwise, it does not print anything.
+
+## Examples
+Here is an example of calling this function, assuming that the tfstate-functions.sentinel file that contains it has been imported with the alias `state`:
+```
+violatingSGRules = state.filter_attribute_contains_items_from_list(SGIngressRules,
+                  "cidr_blocks",forbidden_cidrs, true)
+```

--- a/common-functions/tfstate-functions/docs/filter_attribute_contains_items_not_in_list.md
+++ b/common-functions/tfstate-functions/docs/filter_attribute_contains_items_not_in_list.md
@@ -1,0 +1,30 @@
+# filter_attribute_contains_items_not_in_list
+This function filters a collection of resources, data sources, or blocks to those with an attribute that contains any items that are not in a given list. A policy would call it when it wants the attribute to only contain members of the list (but not necessarily all of them).
+
+## Sentinel Module
+This function is contained in the [tfstate-functions.sentinel](../tfstate-functions.sentinel) module.
+
+## Declaration
+`filter_attribute_contains_items_not_in_list = func(resources, attr, allowed, prtmsg)`
+
+## Arguments
+* **resources**: a map of resources derived from [`tfstate.resources`](https://www.terraform.io/docs/cloud/sentinel/import/tfstate-v2.html#the-resources-collection) or a list of blocks returned by the `find_blocks` function.
+* **attr**: the name of a resource attribute given as a string that should should only contain items from a given list. The attribute should be a list or a map. If the attribute is nested, the various blocks containing it should be delimited with periods (`.`). Indices of lists should not include brackets and should start with 0. So, you would use `boot_disk.0.initialize_params` rather than `boot_disk[0].initialize_params`.
+* **allowed**: a list of values the attribute is allowed to contain. If you want to allow null, include "null" in the list.
+* **prtmsg**: a boolean indicating whether violation messages should be printed (if `true`) or not (if `false`).
+
+## Common Functions Used
+This function calls the [evaluate_attribute](./evaluate_attribute.md) and the [to_string](./to_string.md) functions.
+
+## What It Returns
+This function returns a map with two maps, `resources` and `messages`, both of which are indexed by the complete [addresses](https://www.terraform.io/docs/internals/resource-addressing.html) of the resources, data sources, or blocks that meet the condition of the filter function. The `resources` map contains the actual resource instances for which the attribute (`attr`) contains any items that are not in the list (`allowed`) while the `messages` map contains the violation messages associated with those instances.
+
+## What It Prints
+This function prints the violation messages if the parameter, `prtmsg`, was set to `true`. Otherwise, it does not print anything.
+
+## Examples
+Here is an example of calling this function, assuming that the tfstate-functions.sentinel file that contains it has been imported with the alias `state`:
+```
+violatingIRs = state.filter_attribute_contains_items_not_in_list(ingressRules,
+               "cidr_blocks", allowed_cidrs, false)
+```

--- a/common-functions/tfstate-functions/docs/filter_attribute_does_not_have_prefix.md
+++ b/common-functions/tfstate-functions/docs/filter_attribute_does_not_have_prefix.md
@@ -1,0 +1,35 @@
+# filter_attribute_does_not_have_prefix
+This function filters a collection of resources, data sources, or blocks to those with an attribute that does have a specified prefix. A policy would call it when it wants the attribute to start with that prefix.
+
+It uses Sentinel's standard [strings](https://docs.hashicorp.com/sentinel/imports/strings/) import.
+
+## Sentinel Module
+This function is contained in the [tfstate-functions.sentinel](../tfstate-functions.sentinel) module.
+
+## Declaration
+`filter_attribute_does_not_have_prefix = func(resources, attr, prefix, prtmsg)`
+
+## Arguments
+* **resources**: a map of resources derived from [`tfstate.resources`](https://www.terraform.io/docs/cloud/sentinel/import/tfstate-v2.html#the-resources-collection) or a list of blocks returned by the `find_blocks` function.
+* **attr**: the name of a resource attribute given as a string that should start with the given prefix. If the attribute is nested, the various blocks containing it should be delimited with periods (`.`). Indices of lists should not include brackets and should start with 0. So, you would use `boot_disk.0.initialize_params.0.image` rather than `boot_disk[0].initialize_params[0].image`.
+* **prefix**: the prefix that the attribute should start with.
+* **prtmsg**: a boolean indicating whether violation messages should be printed (if `true`) or not (if `false`).
+
+## Common Functions Used
+This function calls the [evaluate_attribute](./evaluate_attribute.md) and the [to_string](./to_string.md) functions.
+
+## What It Returns
+This function returns a map with two maps, `resources` and `messages`, both of which are indexed by the complete [addresses](https://www.terraform.io/docs/internals/resource-addressing.html) of the resources, data sources, or blocks that meet the condition of the filter function. The `resources` map contains the actual resource instances for which the attribute (`attr`) does not start with `prefix`, while the `messages` map contains the violation messages associated with those instances.
+
+## What It Prints
+This function prints the violation messages if the parameter, `prtmsg`, was set to `true`. Otherwise, it does not print anything.
+
+## Examples
+Here are some examples of calling this function, assuming that the tfstate-functions.sentinel file that contains it has been imported with the alias `state`:
+```
+violatingAccessKeys = state.filter_attribute_does_not_have_prefix(allAccessKeys,
+                      "pgp_key", "keybase:", true)
+
+violatingEC2Instances = state.filter_attribute_does_not_have_prefix(
+                        allEC2Instances, "instance_type", "m5.", true)
+```

--- a/common-functions/tfstate-functions/docs/filter_attribute_does_not_have_suffix.md
+++ b/common-functions/tfstate-functions/docs/filter_attribute_does_not_have_suffix.md
@@ -1,0 +1,35 @@
+# filter_attribute_does_not_have_suffix
+This function filters a collection of resources, data sources, or blocks to those with an attribute that does have a specified suffix. A policy would call it when it wants the attribute to end with that suffix.
+
+It uses Sentinel's standard [strings](https://docs.hashicorp.com/sentinel/imports/strings/) import.
+
+## Sentinel Module
+This function is contained in the [tfstate-functions.sentinel](../tfstate-functions.sentinel) module.
+
+## Declaration
+`filter_attribute_does_not_have_suffix = func(resources, attr, suffix, prtmsg)`
+
+## Arguments
+* **resources**: a map of resources derived from [`tfstate.resources`](https://www.terraform.io/docs/cloud/sentinel/import/tfstate-v2.html#the-resources-collection) or a list of blocks returned by the `find_blocks` function.
+* **attr**: the name of a resource attribute given as a string that should end with the given suffix. If the attribute is nested, the various blocks containing it should be delimited with periods (`.`). Indices of lists should not include brackets and should start with 0. So, you would use `boot_disk.0.initialize_params.0.image` rather than `boot_disk[0].initialize_params[0].image`.
+* **suffix**: the suffix that the attribute should end with.
+* **prtmsg**: a boolean indicating whether violation messages should be printed (if `true`) or not (if `false`).
+
+## Common Functions Used
+This function calls the [evaluate_attribute](./evaluate_attribute.md) and the [to_string](./to_string.md) functions.
+
+## What It Returns
+This function returns a map with two maps, `resources` and `messages`, both of which are indexed by the complete [addresses](https://www.terraform.io/docs/internals/resource-addressing.html) of the resources, data sources, or blocks that meet the condition of the filter function. The `resources` map contains the actual resource instances for which the attribute (`attr`) does not end with `suffix`, while the `messages` map contains the violation messages associated with those instances.
+
+## What It Prints
+This function prints the violation messages if the parameter, `prtmsg`, was set to `true`. Otherwise, it does not print anything.
+
+## Examples
+Here are some examples of calling this function, assuming that the tfstate-functions.sentinel file that contains it has been imported with the alias `state`:
+```
+violatingS3Buckets = state.filter_attribute_does_not_have_suffix(allS3Buckets,
+                      "acl", "-full-control", true)
+
+violatingGCESubnets = state.filter_attribute_does_not_have_suffix(
+                        allGCESubnets, "ip_cidr_range", "/24", true)
+```

--- a/common-functions/tfstate-functions/docs/filter_attribute_does_not_match_regex.md
+++ b/common-functions/tfstate-functions/docs/filter_attribute_does_not_match_regex.md
@@ -1,0 +1,35 @@
+# filter_attribute_does_not_match_regex
+This function filters a collection of resources, data sources, or blocks to those with an attribute that does not match a given regular expression (regex). A policy would call it when it wants the attribute to match that regex.
+
+It uses the Sentinel [matches](https://docs.hashicorp.com/sentinel/language/spec/#matches-operator) operator which uses [RE2](https://github.com/google/re2/wiki/Syntax) regex.
+
+## Sentinel Module
+This function is contained in the [tfstate-functions.sentinel](../tfstate-functions.sentinel) module.
+
+## Declaration
+`filter_attribute_does_not_match_regex = func(resources, attr, expr, prtmsg)`
+
+## Arguments
+* **resources**: a map of resources derived from [`tfstate.resources`](https://www.terraform.io/docs/cloud/sentinel/import/tfstate-v2.html#the-resources-collection) or a list of blocks returned by the `find_blocks` function.
+* **attr**: the name of a resource attribute given as a string that should match the given regex. If the attribute is nested, the various blocks containing it should be delimited with periods (`.`). Indices of lists should not include brackets and should start with 0. So, you would use `boot_disk.0.initialize_params.0.image` rather than `boot_disk[0].initialize_params[0].image`.
+* **expr**: the regex expression that should be matched. Note that any occurrences of `\` need to be escaped with `\` itself since Sentinel allows certain special characters to be escaped with `\`. For example, if you wanted to match sub-domains of ".acme.com", you would set `expr` to `(.+)\\.acme\\.com$` instead of the more usual `(.+)\.acme\.com$`. If you want to allow `null`, set `expr` to `(<regex>|null)`.
+* **prtmsg**: a boolean indicating whether violation messages should be printed (if `true`) or not (if `false`).
+
+## Common Functions Used
+This function calls the [evaluate_attribute](./evaluate_attribute.md) and the [to_string](./to_string.md) functions.
+
+## What It Returns
+This function returns a map with two maps, `resources` and `messages`, both of which are indexed by the complete [addresses](https://www.terraform.io/docs/internals/resource-addressing.html) of the resources, data sources, or blocks that meet the condition of the filter function. The `resources` map contains the actual resource instances for which the attribute (`attr`) does not match the given regex, `expr`, while the `messages` map contains the violation messages associated with those instances.
+
+## What It Prints
+This function prints the violation messages if the parameter, `prtmsg`, was set to `true`. Otherwise, it does not print anything.
+
+## Examples
+Here are some examples of calling this function, assuming that the tfstate-functions.sentinel file that contains it has been imported with the alias `state`:
+```
+violatingACMCerts = state.filter_attribute_does_not_match_regex(allACMCerts,
+                    "domain_name", "(.+)\\.hashidemos\\.io$", true)
+
+violatingAccessKeys = state.filter_attribute_does_not_match_regex(allAccessKeys,
+                      "pgp_key", "^keybase:(.+)", true)
+```

--- a/common-functions/tfstate-functions/docs/filter_attribute_greater_than_value.md
+++ b/common-functions/tfstate-functions/docs/filter_attribute_greater_than_value.md
@@ -1,0 +1,37 @@
+# filter_attribute_greater_than_value
+This function filters a collection of resources, data sources, or blocks to those with an attribute that is greater than a given numeric value. A policy would call it when it wants the attribute to be less than or equal to the given value.
+
+## Sentinel Module
+This function is contained in the [tfstate-functions.sentinel](../tfstate-functions.sentinel) module.
+
+## Declaration
+`filter_attribute_greater_than_value = func(resources, attr, value, prtmsg)`
+
+## Arguments
+* **resources**: a map of resources derived from [`tfstate.resources`](https://www.terraform.io/docs/cloud/sentinel/import/tfstate-v2.html#the-resources-collection) or a list of blocks returned by the `find_blocks` function.
+* **attr**: the name of a resource attribute given as a string that should be less than or equal to a given value. If the attribute is nested, the various blocks containing it should be delimited with periods (`.`). Indices of lists should not include brackets and should start with 0. So, you would use `boot_disk.0.initialize_params.0.image` rather than `boot_disk[0].initialize_params[0].image`.
+* **value**: the value the attribute should be less than or equal to. This should be an integer or a float.
+* **prtmsg**: a boolean indicating whether violation messages should be printed (if `true`) or not (if `false`).
+
+## Common Functions Used
+This function calls the [evaluate_attribute](./evaluate_attribute.md) and the [to_string](./to_string.md) functions.
+
+## What It Returns
+This function returns a map with two maps, `resources` and `messages`, both of which are indexed by the complete [addresses](https://www.terraform.io/docs/internals/resource-addressing.html) of the resources, data sources, or blocks that meet the condition of the filter function. The `resources` map contains the actual resource instances for which the attribute (`attr`) is greater than the given value, `value`, while the `messages` map contains the violation messages associated with those instances.
+
+## What It Prints
+This function prints the violation messages if the parameter, `prtmsg`, was set to `true`. Otherwise, it does not print anything.
+
+## Examples
+Here are some examples of calling this function, assuming that the tfstate-functions.sentinel file that contains it has been imported with the alias `state`:
+```
+highCPUVMs = state.filter_attribute_greater_than_value(allVMs,
+             "num_cpus", maxCPUs, true)
+
+
+highMemoryVMs = state.filter_attribute_greater_than_value(allVMs,
+                "memory", maxMemory, true)
+
+violatingDisks = state.filter_attribute_greater_than_value(disks,
+                 "size", maxDiskSize, false)
+```

--- a/common-functions/tfstate-functions/docs/filter_attribute_has_prefix.md
+++ b/common-functions/tfstate-functions/docs/filter_attribute_has_prefix.md
@@ -1,0 +1,35 @@
+# filter_attribute_has_prefix
+This function filters a collection of resources, data sources, or blocks to those with an attribute that has a specified prefix. A policy would call it when it wants the attribute to not start with that prefix.
+
+It uses Sentinel's standard [strings](https://docs.hashicorp.com/sentinel/imports/strings/) import.
+
+## Sentinel Module
+This function is contained in the [tfstate-functions.sentinel](../tfstate-functions.sentinel) module.
+
+## Declaration
+`filter_attribute_has_prefix = func(resources, attr, prefix, prtmsg)`
+
+## Arguments
+* **resources**: a map of resources derived from [`tfstate.resources`](https://www.terraform.io/docs/cloud/sentinel/import/tfstate-v2.html#the-resources-collection) or a list of blocks returned by the `find_blocks` function.
+* **attr**: the name of a resource attribute given as a string that should not start with the given prefix. If the attribute is nested, the various blocks containing it should be delimited with periods (`.`). Indices of lists should not include brackets and should start with 0. So, you would use `boot_disk.0.initialize_params.0.image` rather than `boot_disk[0].initialize_params[0].image`.
+* **prefix**: the prefix that the attribute should not start with.
+* **prtmsg**: a boolean indicating whether violation messages should be printed (if `true`) or not (if `false`).
+
+## Common Functions Used
+This function calls the [evaluate_attribute](./evaluate_attribute.md) and the [to_string](./to_string.md) functions.
+
+## What It Returns
+This function returns a map with two maps, `resources` and `messages`, both of which are indexed by the complete [addresses](https://www.terraform.io/docs/internals/resource-addressing.html) of the resources, data sources, or blocks that meet the condition of the filter function. The `resources` map contains the actual resource instances for which the attribute (`attr`) starts with `prefix`, while the `messages` map contains the violation messages associated with those instances.
+
+## What It Prints
+This function prints the violation messages if the parameter, `prtmsg`, was set to `true`. Otherwise, it does not print anything.
+
+## Examples
+Here are some examples of calling this function, assuming that the tfstate-functions.sentinel file that contains it has been imported with the alias `state`:
+```
+violatingAccessKeys = state.filter_attribute_has_prefix(allAccessKeys,
+                      "pgp_key", "keybase:", true)
+
+violatingAzureVMs = state.filter_attribute_has_prefix(
+                        allAzureVMs, "vm_size", "Standard_", true)
+```

--- a/common-functions/tfstate-functions/docs/filter_attribute_has_suffix.md
+++ b/common-functions/tfstate-functions/docs/filter_attribute_has_suffix.md
@@ -1,0 +1,35 @@
+# filter_attribute_has_suffix
+This function filters a collection of resources, data sources, or blocks to those with an attribute that has a specified suffix. A policy would call it when it wants the attribute to not end with that suffix.
+
+It uses Sentinel's standard [strings](https://docs.hashicorp.com/sentinel/imports/strings/) import.
+
+## Sentinel Module
+This function is contained in the [tfstate-functions.sentinel](../tfstate-functions.sentinel) module.
+
+## Declaration
+`filter_attribute_has_suffix = func(resources, attr, suffix, prtmsg)`
+
+## Arguments
+* **resources**: a map of resources derived from [`tfstate.resources`](https://www.terraform.io/docs/cloud/sentinel/import/tfstate-v2.html#the-resources-collection) or a list of blocks returned by the `find_blocks` function.
+* **attr**: the name of a resource attribute given as a string that should not end with the given suffix. If the attribute is nested, the various blocks containing it should be delimited with periods (`.`). Indices of lists should not include brackets and should start with 0. So, you would use `boot_disk.0.initialize_params.0.image` rather than `boot_disk[0].initialize_params[0].image`.
+* **suffix**: the suffix that the attribute should not end with.
+* **prtmsg**: a boolean indicating whether violation messages should be printed (if `true`) or not (if `false`).
+
+## Common Functions Used
+This function calls the [evaluate_attribute](./evaluate_attribute.md) and the [to_string](./to_string.md) functions.
+
+## What It Returns
+This function returns a map with two maps, `resources` and `messages`, both of which are indexed by the complete [addresses](https://www.terraform.io/docs/internals/resource-addressing.html) of the resources, data sources, or blocks that meet the condition of the filter function. The `resources` map contains the actual resource instances for which the attribute (`attr`) ends with `suffix`, while the `messages` map contains the violation messages associated with those instances.
+
+## What It Prints
+This function prints the violation messages if the parameter, `prtmsg`, was set to `true`. Otherwise, it does not print anything.
+
+## Examples
+Here are some examples of calling this function, assuming that the tfstate-functions.sentinel file that contains it has been imported with the alias `state`:
+```
+violatingS3Buckets = state.filter_attribute_has_suffix(allS3Buckets,
+                      "acl", "-full-control", true)
+
+violatingGCESubnets = state.filter_attribute_has_suffix(
+                        allGCESubnets, "ip_cidr_range", "/8", true)
+```

--- a/common-functions/tfstate-functions/docs/filter_attribute_in_list.md
+++ b/common-functions/tfstate-functions/docs/filter_attribute_in_list.md
@@ -1,0 +1,36 @@
+# filter_attribute_in_list
+This function filters a collection of resources, data sources, or blocks to those with an attribute contained in a provided list. A policy would call it when it does not want the attribute set to any member of the list.
+
+## Sentinel Module
+This function is contained in the [tfstate-functions.sentinel](../tfstate-functions.sentinel) module.
+
+## Declaration
+`filter_attribute_in_list = func(resources, attr, forbidden, prtmsg)`
+
+## Arguments
+* **resources**: a map of resources derived from [`tfstate.resources`](https://www.terraform.io/docs/cloud/sentinel/import/tfstate-v2.html#the-resources-collection) or a list of blocks returned by the `find_blocks` function.
+* **attr**: the name of a resource attribute given as a string that must not be in a given list. If the attribute is nested, the various blocks containing it should be delimited with periods (`.`). Indices of lists should not include brackets and should start with 0. So, you would use `boot_disk.0.initialize_params.0.image` rather than `boot_disk[0].initialize_params[0].image`.
+* **forbidden**: a list of values the attribute is forbidden to have. If you want to disallow null, include "null" in the list.
+* **prtmsg**: a boolean indicating whether violation messages should be printed (if `true`) or not (if `false`).
+
+## Common Functions Used
+This function calls the [evaluate_attribute](./evaluate_attribute.md) and the [to_string](./to_string.md) functions.
+
+## What It Returns
+This function returns a map with two maps, `resources` and `messages`, both of which are indexed by the complete [addresses](https://www.terraform.io/docs/internals/resource-addressing.html) of the resources, data sources, or blocks that meet the condition of the filter function. The `resources` map contains the actual resource instances for which the attribute (`attr`) is in in the list (`forbidden`) while the `messages` map contains the violation messages associated with those instances.
+
+## What It Prints
+This function prints the violation messages if the parameter, `prtmsg`, was set to `true`. Otherwise, it does not print anything.
+
+## Examples
+Here are some examples of calling this function, assuming that the tfstate-functions.sentinel file that contains it has been imported with the alias `state`:
+```
+violatingEC2Instances = state.filter_attribute_in_list(allEC2Instances,
+                        "instance_type", forbidden_types, true)
+
+violatingAzureVMs = state.filter_attribute_in_list(allAzureVMs,
+                    "vm_size", forbidden_sizes, true)
+
+violatingGCEInstances = state.filter_attribute_in_list(allGCEInstances,
+                        "machine_type", forbidden_types, true)
+```

--- a/common-functions/tfstate-functions/docs/filter_attribute_is_not_value.md
+++ b/common-functions/tfstate-functions/docs/filter_attribute_is_not_value.md
@@ -1,0 +1,37 @@
+# filter_attribute_is_not_value
+This function filters a collection of resources, data sources, or blocks to those with an attribute that is not equal to a given value. A policy would call it when it wants the attribute to equal the given value.
+
+## Sentinel Module
+This function is contained in the [tfstate-functions.sentinel](../tfstate-functions.sentinel) module.
+
+## Declaration
+`filter_attribute_is_not_value = func(resources, attr, value, prtmsg)`
+
+## Arguments
+* **resources**: a map of resources derived from [`tfstate.resources`](https://www.terraform.io/docs/cloud/sentinel/import/tfstate-v2.html#the-resources-collection) or a list of blocks returned by the `find_blocks` function.
+* **attr**: the name of a resource attribute given as a string that should equal a given value. If the attribute is nested, the various blocks containing it should be delimited with periods (`.`). Indices of lists should not include brackets and should start with 0. So, you would use `boot_disk.0.initialize_params.0.image` rather than `boot_disk[0].initialize_params[0].image`.
+* **value**: the value the attribute should have. This can be any primitive data type.
+* **prtmsg**: a boolean indicating whether violation messages should be printed (if `true`) or not (if `false`).
+
+## Common Functions Used
+This function calls the [evaluate_attribute](./evaluate_attribute.md) and the [to_string](./to_string.md) functions.
+
+## What It Returns
+This function returns a map with two maps, `resources` and `messages`, both of which are indexed by the complete [addresses](https://www.terraform.io/docs/internals/resource-addressing.html) of the resources, data sources, or blocks that meet the condition of the filter function. The `resources` map contains the actual resource instances for which the attribute (`attr`) is not equal to the given value, `value`, while the `messages` map contains the violation messages associated with those instances.
+
+## What It Prints
+This function prints the violation messages if the parameter, `prtmsg`, was set to `true`. Otherwise, it does not print anything.
+
+## Examples
+Here are some examples of calling this function, assuming that the tfstate-functions.sentinel file that contains it has been imported with the alias `state`:
+```
+nonPrivateS3Buckets = state.filter_attribute_is_not_value(allS3Buckets,
+                      "acl", "private", true)
+
+nonEncryptedS3Buckets = state.filter_attribute_is_not_value(allS3Buckets,
+  "server_side_encryption_configuration.0.rule.0.apply_server_side_encryption_by_default.0.sse_algorithm",
+  "aws:kms", true)
+
+violatingAzureAppServices = state.filter_attribute_is_not_value(allAzureAppServices,
+                            "https_only", true, true)
+```

--- a/common-functions/tfstate-functions/docs/filter_attribute_is_value.md
+++ b/common-functions/tfstate-functions/docs/filter_attribute_is_value.md
@@ -1,0 +1,34 @@
+# filter_attribute_is_value
+This function filters a collection of resources, data sources, or blocks to those with an attribute that is equal to a given value. A policy would call it when it wants the attribute to not equal the given value.
+
+## Sentinel Module
+This function is contained in the [tfstate-functions.sentinel](../tfstate-functions.sentinel) module.
+
+## Declaration
+`filter_attribute_is_value = func(resources, attr, value, prtmsg)`
+
+## Arguments
+* **resources**: a map of resources derived from [`tfstate.resources`](https://www.terraform.io/docs/cloud/sentinel/import/tfstate-v2.html#the-resources-collection) or a list of blocks returned by the `find_blocks` function.
+* **attr**: the name of a resource attribute given as a string that should not equal a given value. If the attribute is nested, the various blocks containing it should be delimited with periods (`.`). Indices of lists should not include brackets and should start with 0. So, you would use `boot_disk.0.initialize_params.0.image` rather than `boot_disk[0].initialize_params[0].image`.
+* **value**: the value the attribute should not have. This can be any primitive data type. If you want to match null, set value to "null".
+* **prtmsg**: a boolean indicating whether violation messages should be printed (if `true`) or not (if `false`).
+
+## Common Functions Used
+This function calls the [evaluate_attribute](./evaluate_attribute.md) and the [to_string](./to_string.md) functions.
+
+## What It Returns
+This function returns a map with two maps, `resources` and `messages`, both of which are indexed by the complete [addresses](https://www.terraform.io/docs/internals/resource-addressing.html) of the resources, data sources, or blocks that meet the condition of the filter function. The `resources` map contains the actual resource instances for which the attribute (`attr`) is equal to the given value, `value`, while the `messages` map contains the violation messages associated with those instances.
+
+## What It Prints
+This function prints the violation messages if the parameter, `prtmsg`, was set to `true`. Otherwise, it does not print anything.
+
+## Examples
+Here are some examples of calling this function, assuming that the tfstate-functions.sentinel file that contains it has been imported with the alias `state`:
+```
+nonPrivateS3Buckets = state.filter_attribute_is_value(allS3Buckets,
+                      "acl", "public_read", true)
+
+
+violatingAzureAppServices = state.filter_attribute_is_value(allAzureAppServices,
+                            "https_only", false, true)
+```

--- a/common-functions/tfstate-functions/docs/filter_attribute_less_than_value.md
+++ b/common-functions/tfstate-functions/docs/filter_attribute_less_than_value.md
@@ -1,0 +1,34 @@
+# filter_attribute_less_than_value
+This function filters a collection of resources, data sources, or blocks to those with an attribute that is less than a given numeric value. A policy would call it when it wants the attribute to be greater than or equal to the given value.
+
+## Sentinel Module
+This function is contained in the [tfstate-functions.sentinel](../tfstate-functions.sentinel) module.
+
+## Declaration
+`filter_attribute_less_than_value = func(resources, attr, value, prtmsg)`
+
+## Arguments
+* **resources**: a map of resources derived from [`tfstate.resources`](https://www.terraform.io/docs/cloud/sentinel/import/tfstate-v2.html#the-resources-collection) or a list of blocks returned by the `find_blocks` function.
+* **attr**: the name of a resource attribute given as a string that should be greater than or equal to a given value. If the attribute is nested, the various blocks containing it should be delimited with periods (`.`). Indices of lists should not include brackets and should start with 0. So, you would use `boot_disk.0.initialize_params.0.image` rather than `boot_disk[0].initialize_params[0].image`.
+* **value**: the value the attribute should be greater than or equal to. This should be an integer or a float.
+* **prtmsg**: a boolean indicating whether violation messages should be printed (if `true`) or not (if `false`).
+
+## Common Functions Used
+This function calls the [evaluate_attribute](./evaluate_attribute.md) and the [to_string](./to_string.md) functions.
+
+## What It Returns
+This function returns a map with two maps, `resources` and `messages`, both of which are indexed by the complete [addresses](https://www.terraform.io/docs/internals/resource-addressing.html) of the resources, data sources, or blocks that meet the condition of the filter function. The `resources` map contains the actual resource instances for which the attribute (`attr`) is less than the given value, `value`, while the `messages` map contains the violation messages associated with those instances.
+
+## What It Prints
+This function prints the violation messages if the parameter, `prtmsg`, was set to `true`. Otherwise, it does not print anything.
+
+## Examples
+Here are some examples of calling this function, assuming that the tfstate-functions.sentinel file that contains it has been imported with the alias `state`:
+```
+lowCPUVMs = state.filter_attribute_less_than_value(allVMs,
+             "num_cpus", minCPUs, true)
+
+
+lowMemoryVMs = state.filter_attribute_less_than_value(allVMs,
+                "memory", minMemory, true)
+```

--- a/common-functions/tfstate-functions/docs/filter_attribute_matches_regex.md
+++ b/common-functions/tfstate-functions/docs/filter_attribute_matches_regex.md
@@ -1,0 +1,35 @@
+# filter_attribute_matches_regex
+This function filters a collection of resources, data sources, or blocks to those with an attribute that matches a given regular expression (regex). A policy would call it when it wants the attribute to not match that regex.
+
+It uses the Sentinel [matches](https://docs.hashicorp.com/sentinel/language/spec/#matches-operator) operator which uses [RE2](https://github.com/google/re2/wiki/Syntax) regex.
+
+## Sentinel Module
+This function is contained in the [tfstate-functions.sentinel](../tfstate-functions.sentinel) module.
+
+## Declaration
+`filter_attribute_matches_regex = func(resources, attr, expr, prtmsg)`
+
+## Arguments
+* **resources**: a map of resources derived from [`tfstate.resources`](https://www.terraform.io/docs/cloud/sentinel/import/tfstate-v2.html#the-resources-collection) or a list of blocks returned by the `find_blocks` function.
+* **attr**: the name of a resource attribute given as a string that should match the given regex. If the attribute is nested, the various blocks containing it should be delimited with periods (`.`). Indices of lists should not include brackets and should start with 0. So, you would use `boot_disk.0.initialize_params.0.image` rather than `boot_disk[0].initialize_params[0].image`.
+* **expr**: the regex expression that should be matched. Note that any occurrences of `\` need to be escaped with `\` itself since Sentinel allows certain special characters to be escaped with `\`. For example, if you did not want to match sub-domains of ".acme.com", you would set `expr` to `(.+)\\.acme\\.com$` instead of the more usual `(.+)\.acme\.com$`. If you want to match null, set expr to "null".
+* **prtmsg**: a boolean indicating whether violation messages should be printed (if `true`) or not (if `false`).
+
+## Common Functions Used
+This function calls the [evaluate_attribute](./evaluate_attribute.md) and the [to_string](./to_string.md) functions.
+
+## What It Returns
+This function returns a map with two maps, `resources` and `messages`, both of which are indexed by the complete [addresses](https://www.terraform.io/docs/internals/resource-addressing.html) of the resources, data sources, or blocks that meet the condition of the filter function. The `resources` map contains the actual resource instances for which the attribute (`attr`) matches the given regex, `expr`, while the `messages` map contains the violation messages associated with those instances.
+
+## What It Prints
+This function prints the violation messages if the parameter, `prtmsg`, was set to `true`. Otherwise, it does not print anything.
+
+## Examples
+Here are some examples of calling this function, assuming that the tfstate-functions.sentinel file that contains it has been imported with the alias `state`:
+```
+violatingACMCerts = state.filter_attribute_matches_regex(allACMCerts,
+                    "domain_name", "(.+)\\.hashidemos\\.io$", true)
+
+violatingAccessKeys = state.filter_attribute_matches_regex(allAccessKeys,
+                      "pgp_key", "^keybase:(.+)", true)
+```

--- a/common-functions/tfstate-functions/docs/filter_attribute_not_contains_list.md
+++ b/common-functions/tfstate-functions/docs/filter_attribute_not_contains_list.md
@@ -1,0 +1,36 @@
+# filter_attribute_not_contains_list
+This function filters a collection of resources, data sources, or blocks to those with an attribute that does not contain all members of a given list. A policy would call it when it wants the attribute to contain all members of the list.
+
+## Sentinel Module
+This function is contained in the [tfstate-functions.sentinel](../tfstate-functions.sentinel) module.
+
+## Declaration
+`filter_attribute_not_contains_list = func(resources, attr, required, prtmsg)`
+
+## Arguments
+* **resources**: a map of resources derived from [`tfstate.resources`](https://www.terraform.io/docs/cloud/sentinel/import/tfstate-v2.html#the-resources-collection) or a list of blocks returned by the `find_blocks` function.
+* **attr**: the name of a resource attribute given as a string that must contain all items from a given list. The attribute should be a list or map. If the attribute is nested, the various blocks containing it should be delimited with periods (`.`). Indices of lists should not include brackets and should start with 0. So, you would use `boot_disk.0.initialize_params` rather than `boot_disk[0].initialize_params`.
+* **required**: a list of values all of which the attribute should contain.
+* **prtmsg**: a boolean indicating whether violation messages should be printed (if `true`) or not (if `false`).
+
+## Common Functions Used
+This function calls the [evaluate_attribute](./evaluate_attribute.md) and the [to_string](./to_string.md) functions.
+
+## What It Returns
+This function returns a map with two maps, `resources` and `messages`, both of which are indexed by the complete [addresses](https://www.terraform.io/docs/internals/resource-addressing.html) of the resources, data sources, or blocks that meet the condition of the filter function. The `resources` map contains the actual resource instances for which the attribute (`attr`) does not contain all items of the list (`required`) while the `messages` map contains the violation messages associated with those instances.
+
+## What It Prints
+This function prints the violation messages if the parameter, `prtmsg`, was set to `true`. Otherwise, it does not print anything.
+
+## Examples
+Here are some examples of calling this function, assuming that the tfstate-functions.sentinel file that contains it has been imported with the alias `state`:
+```
+violatingEC2Instances = state.filter_attribute_not_contains_list(allEC2Instances,
+                        "tags", mandatory_tags, true)
+
+violatingAzureVMs = state.filter_attribute_not_contains_list(allAzureVMs,
+                    "tags", mandatory_tags, true)
+
+violatingGCEInstances = state.filter_attribute_not_contains_list(allGCEInstances,
+                        "labels", mandatory_labels, true)
+```

--- a/common-functions/tfstate-functions/docs/filter_attribute_not_in_list.md
+++ b/common-functions/tfstate-functions/docs/filter_attribute_not_in_list.md
@@ -1,0 +1,38 @@
+# filter_attribute_not_in_list
+This function filters a collection of resources, data sources, or blocks to those with an attribute that is not contained in a provided list. A policy would call it when it wants the attribute to have a value from the list.
+
+## Sentinel Module
+This function is contained in the [tfstate-functions.sentinel](../tfstate-functions.sentinel) module.
+
+## Declaration
+`filter_attribute_not_in_list = func(resources, attr, allowed, prtmsg)`
+
+## Arguments
+* **resources**: a map of resources derived from [`tfstate.resources`](https://www.terraform.io/docs/cloud/sentinel/import/tfstate-v2.html#the-resources-collection) or a list of blocks returned by the `find_blocks` function.
+* **attr**: the name of a resource attribute given as a string that must be in a given list. If the attribute is nested, the various blocks containing it should be delimited with periods (`.`). Indices of lists should not include brackets and should start with 0. So, you would use `boot_disk.0.initialize_params.0.image` rather than `boot_disk[0].initialize_params[0].image`.
+* **allowed**: a list of values the attribute is allowed to have. If you want to allow null, include "null" in the list.
+* **prtmsg**: a boolean indicating whether violation messages should be printed (if `true`) or not (if `false`).
+
+## Common Functions Used
+This function calls the [evaluate_attribute](./evaluate_attribute.md) and the [to_string](./to_string.md) functions.
+
+## What It Returns
+This function returns a map with two maps, `resources` and `messages`, both of which are indexed by the complete [addresses](https://www.terraform.io/docs/internals/resource-addressing.html) of the resources, data sources, or blocks that meet the condition of the filter function. The `resources` map contains the actual resource instances for which the attribute (`attr`) is not in the list (`allowed`) while the `messages` map contains the violation messages associated with those instances.
+
+## What It Prints
+This function prints the violation messages if the parameter, `prtmsg`, was set to `true`. Otherwise, it does not print anything.
+
+## Examples
+Here are some examples of calling this function, assuming that the tfstate-functions.sentinel file that contains it has been imported with the alias `state`:
+```
+violatingEC2Instances = state.filter_attribute_not_in_list(allEC2Instances,
+                        "instance_type", allowed_types, true)
+
+violatingAzureVMs = state.filter_attribute_not_in_list(allAzureVMs,
+                    "vm_size", allowed_sizes, true)
+
+violatingGCEInstances = state.filter_attribute_not_in_list(allGCEInstances,
+                        "machine_type", allowed_types, true)
+```
+
+This function is used by the [restrict-current-ec2-instance-type.sentinel (AWS)](../../../aws/restrict-current-ec2-instance-type.sentinel) and [restrict-publishers-of-current-vms.sentinel (Azure)](https://github.com/rberlind/terraform-guides/blob/master/governance/third-generation/azure/restrict-publishers-of-current-vms.sentinel) policies.

--- a/common-functions/tfstate-functions/docs/find_blocks.md
+++ b/common-functions/tfstate-functions/docs/find_blocks.md
@@ -1,0 +1,29 @@
+# find_blocks
+This function finds all blocks of a specific type under a single resource or block in the state of the current workspace using the [tfstate/v2](https://www.terraform.io/docs/cloud/sentinel/import/tfstate-v2.html) import.
+
+## Sentinel Module
+This function is contained in the [tfstate-functions.sentinel](../tfstate-functions.sentinel) module.
+
+## Declaration
+`find_blocks = func(parent, child)`
+
+## Arguments
+* **parent**: a single resource or block of a resource
+* **child**: a string representing the child blocks to be found in the parent.
+
+## Common Functions Used
+None
+
+## What It Returns
+This function returns a single list of child blocks found in the parent resource or block. Each child block is represented by a map.
+
+## What It Prints
+This function does not print anything.
+
+## Examples
+Here are some examples of calling this function, assuming that the tfstate-functions.sentinel file that contains it has been imported with the alias `state`:
+```
+ingressRules = state.find_blocks(sg, "ingress")
+
+disks = state.find_blocks(vm, "disk")
+```

--- a/common-functions/tfstate-functions/docs/find_datasources.md
+++ b/common-functions/tfstate-functions/docs/find_datasources.md
@@ -1,0 +1,34 @@
+# find_datasources
+This function finds all data source instances of a specific type in the state of the current workspace using the [tfstate/v2](https://www.terraform.io/docs/cloud/sentinel/import/tfstate-v2.html) import.
+
+## Sentinel Module
+This function is contained in the [tfstate-functions.sentinel](../tfstate-functions.sentinel) module.
+
+## Declaration
+`find_datasources = func(type)`
+
+## Arguments
+* **type**: the type of datasource to find, given as a string.
+
+## Common Functions Used
+None
+
+## What It Returns
+This function returns a single flat map of data source instances indexed by the complete [addresses](https://www.terraform.io/docs/internals/resource-addressing.html) of the instances. The map is actually a filtered sub-collection of the [`tfstate.resources`](https://www.terraform.io/docs/cloud/sentinel/import/tfstate-v2.html#the-resources-collection) collection.
+
+## What It Prints
+This function does not print anything.
+
+## Examples
+Here are some examples of calling this function, assuming that the tfstate-functions.sentinel file that contains it has been imported with the alias `state`:
+```
+currentAMIs = state.find_datasources("aws_ami")
+
+currentImages = state.find_datasources("azurerm_image")
+
+currentImages = state.find_datasources("google_compute_image")
+
+currentDatastores = state.find_datasources("vsphere_datastore")
+```
+
+This function is used by the [restrict-ami-owners.sentinel (AWS)](../../../aws/restrict-ami-owners.sentinel) policy.

--- a/common-functions/tfstate-functions/docs/find_datasources_by_provider.md
+++ b/common-functions/tfstate-functions/docs/find_datasources_by_provider.md
@@ -1,0 +1,36 @@
+# find_datasources_by_provider
+This function finds all data source instances for a specific provider in the state of the current workspace using the [tfstate/v2](https://www.terraform.io/docs/cloud/sentinel/import/tfstate-v2.html) import.
+
+If you are using Terraform 0.12, use the short form of the provider name such as "null". If you are using Terraform 0.13, you can use the short form or the fully-qualified provider source such as "registry.terraform.io/hashicorp/null", but only use the latter if you are only want to find resources from a specific registry. If you use the short form, the function will reduce `rc.provider_name` for each resource to the short form, but if you use the long form, it will not.
+
+## Sentinel Module
+This function is contained in the [tfstate-functions.sentinel](../tfstate-functions.sentinel) module.
+
+## Declaration
+`find_datasources_by_provider = func(provider)`
+
+## Arguments
+* **provider**: the provider, given as a string.
+
+## Common Functions Used
+None
+
+## What It Returns
+This function returns a single flat map of data source instances indexed by the complete [addresses](https://www.terraform.io/docs/internals/resource-addressing.html) of the instances. The map is actually a filtered sub-collection of the [`tfstate.resources`](https://www.terraform.io/docs/cloud/sentinel/import/tfstate-v2.html#the-resources-collection) collection.
+
+## What It Prints
+This function does not print anything.
+
+## Examples
+Here are some examples of calling this function, assuming that the tfstate-functions.sentinel file that contains it has been imported with the alias `state`:
+```
+currentAWSDataSources = state.find_datasources_by_provider("aws")
+
+currentAWSDataSources = state.find_datasources_by_provider("registry.terraform.io/hashicorp/aws")
+
+currentAzureDataSources = state.find_datasources_by_provider("azurerm")
+
+currentGCPDataSources = state.find_datasources_by_provider("google")
+
+currentVMwareDataSources = state.find_datasources_by_provider("vsphere")
+```

--- a/common-functions/tfstate-functions/docs/find_resources.md
+++ b/common-functions/tfstate-functions/docs/find_resources.md
@@ -1,0 +1,34 @@
+# find_resources
+This function finds all resource instances of a specific type in the state of the current workspace using the [tfstate/v2](https://www.terraform.io/docs/cloud/sentinel/import/tfstate-v2.html) import.
+
+## Sentinel Module
+This function is contained in the [tfstate-functions.sentinel](../tfstate-functions.sentinel) module.
+
+## Declaration
+`find_resources = func(type)`
+
+## Arguments
+* **type**: the type of resource to find, given as a string.
+
+## Common Functions Used
+None
+
+## What It Returns
+This function returns a single flat map of resource instances indexed by the complete [addresses](https://www.terraform.io/docs/internals/resource-addressing.html) of the instances. The map is actually a filtered sub-collection of the [`tfstate.resources`](https://www.terraform.io/docs/cloud/sentinel/import/tfstate-v2.html#the-resources-collection) collection.
+
+## What It Prints
+This function does not print anything.
+
+## Examples
+Here are some examples of calling this function, assuming that the tfstate-functions.sentinel file that contains it has been imported with the alias `state`:
+```
+currentEC2Instances = state.find_resources("aws_instance")
+
+currentAzureVMs = state.find_resources("azurerm_virtual_machine")
+
+currentGCEInstances = state.find_resources("google_compute_instance")
+
+currentVMs = state.find_resources("vsphere_virtual_machine")
+```
+
+This function is used by several policies including [restrict-current-ec2-instance-type.sentinel (AWS)](../../../aws/restrict-current-ec2-instance-type.sentinel) and [restrict-publishers-of-current-vms.sentinel (Azure)](../../../azure/restrict-publishers-of-current-vms..sentinel).

--- a/common-functions/tfstate-functions/docs/find_resources_by_provider.md
+++ b/common-functions/tfstate-functions/docs/find_resources_by_provider.md
@@ -1,0 +1,36 @@
+# find_resources_by_provider
+This function finds all resource instances for a specific provider in the state of the current workspace using the [tfstate/v2](https://www.terraform.io/docs/cloud/sentinel/import/tfstate-v2.html) import.
+
+If you are using Terraform 0.12, use the short form of the provider name such as "null". If you are using Terraform 0.13, you can use the short form or the fully-qualified provider source such as "registry.terraform.io/hashicorp/null", but only use the latter if you are only want to find resources from a specific registry. If you use the short form, the function will reduce `rc.provider_name` for each resource to the short form, but if you use the long form, it will not.
+
+## Sentinel Module
+This function is contained in the [tfstate-functions.sentinel](../tfstate-functions.sentinel) module.
+
+## Declaration
+`find_resources_by_provider = func(provider)`
+
+## Arguments
+* **provider**: the provider, given as a string.
+
+## Common Functions Used
+None
+
+## What It Returns
+This function returns a single flat map of resource instances indexed by the complete [addresses](https://www.terraform.io/docs/internals/resource-addressing.html) of the instances. The map is actually a filtered sub-collection of the [`tfstate.resources`](https://www.terraform.io/docs/cloud/sentinel/import/tfstate-v2.html#the-resources-collection) collection.
+
+## What It Prints
+This function does not print anything.
+
+## Examples
+Here are some examples of calling this function, assuming that the tfstate-functions.sentinel file that contains it has been imported with the alias `state`:
+```
+currentEC2Resources = state.find_resources_by_provider("aws")
+
+currentEC2Resources = state.find_resources_by_provider("registry.terraform.io/hashicorp/aws")
+
+currentAzureResources = state.find_resources_by_provider("azurerm")
+
+currentGCPResources = state.find_resources_by_provider("google")
+
+currentVMwareResources = state.find_resources_by_provider("vsphere")
+```

--- a/common-functions/tfstate-functions/docs/print_violations.md
+++ b/common-functions/tfstate-functions/docs/print_violations.md
@@ -1,0 +1,38 @@
+# print_violations
+This function prints the violation messages that were previously returned by one of the filter functions of the tfstate-functions.sentinel module. While those filter functions can print the violations messages themselves (if their `prtmsg` parameter is set to `true`), it is sometimes preferable to delay printing of the messages until later in the policy, typically after printing one or more messages giving the address of the resource that violated it.
+
+## Sentinel Module
+This function is contained in the [tfstate-functions.sentinel](../tfstate-functions.sentinel) module.
+
+## Declaration
+`print_violations = func(messages, prefix)`
+
+## Arguments
+* **messages**: a map of messages returned by one of the filter functions.
+* **prefix**: a string that should be printed before each message.
+
+## Common Functions Used
+None
+
+## What It Returns
+This function always returns `true`.
+
+## What It Prints
+This function prints the messages in the `messages` map prefixed with the `prefix` string.
+
+## Examples
+Here are some examples of calling this function, assuming that the tfstate-functions.sentinel file that contains it has been imported with the alias `state`:
+```
+if length(violatingIRs["messages"]) > 0 {
+  violatingSGsCount += 1
+  print("SG Ingress Violation:", address, "has at least one ingress rule",
+        "with forbidden cidr blocks")
+  state.print_violations(violatingIRs["messages"], "Ingress Rule")
+}
+
+if length(violatingDisks["messages"]) > 0 {
+  disksValidated = false
+  print(address, "has at least one disk with size greater than", maxDiskSize)
+  state.print_violations(violatingDisks["messages"], "Disk")
+}
+```

--- a/common-functions/tfstate-functions/docs/to_string.md
+++ b/common-functions/tfstate-functions/docs/to_string.md
@@ -1,0 +1,28 @@
+# to_string
+This function converts any Sentinel object including complex compositions of primitive types (string, int, float, and bool), null, undefined, lists, and maps to a string.
+
+## Sentinel Module
+This function is contained in the [tfstate-functions.sentinel](../tfstate-functions.sentinel) module.
+
+## Declaration
+`to_string = func(obj)`
+
+## Arguments
+* **obj**: a Sentinel object of any type
+
+## Common Functions Used
+This function calls itself recursively to support composite objects.
+
+## What It Returns
+This function returns a single string.
+
+## What It Prints
+This function does not print anything.
+
+## Examples
+This function is called by all of the filter functions in the tfstate-functions.sentinel module. Here is a typical example:
+```
+message = to_string(address) + " has " + to_string(attr) + " with value " +
+          to_string(v) + " that is not in the allowed list: " +
+          to_string(allowed)
+```

--- a/common-functions/tfstate-functions/tfstate-functions.sentinel
+++ b/common-functions/tfstate-functions/tfstate-functions.sentinel
@@ -1,0 +1,866 @@
+# Common functions that use the tfstate/v2 import
+
+# The filter functions all accept a collection of resources, an attribute,
+# a value or a list of values, and a boolean, prtmsg, which can be true or false
+# and indicates whether the filter function should print violation messages.
+# The filter functions return a map consisting of 2 items:
+#   * "resources": a map consisting of resources that violate a condition
+#   * "messages":  a map of violation messages associated with the resources
+# Note that both the resources and messages collections are indexed by the
+# address of the resources, so they will have the same order and length.
+# The filter functions all call evaluate_attribute() to evaluate attributes
+# of resources even if nested deep within them.
+
+##### Imports #####
+import "tfstate/v2" as tfstate
+import "strings"
+import "types"
+
+##### Functions #####
+
+### find_resources ###
+# Find all resources of a specific type using the tfstate/v2 import.
+find_resources = func(type) {
+	resources = filter tfstate.resources as address, r {
+		r.type is type and
+			r.mode is "managed"
+	}
+
+	return resources
+}
+
+### find_resources_by_provider ###
+# Find all resources for a specific provider using the tfstate/v2 import.
+# Terraform 0.12 and earlier set `r.provider_name` to short text like "null";
+# but Terraform 0.13 and higher set it to something like
+# "registry.terraform.io/hashicorp/null".
+# You can pass in the long form or short form.
+find_resources_by_provider = func(provider) {
+	parsed_provider = strings.split(provider, "/")
+	segment_count = length(parsed_provider)
+	v = strings.split(tfstate.terraform_version, ".")
+	v_major = int(v[1])
+
+	# If v_major is 12, we know short form was passed to Sentinel
+	if v_major is 12 {
+		resources = filter tfstate.resources as address, r {
+			r.provider_name is provider and
+				r.mode is "managed"
+		}
+	} else {
+		# v_major must be higher than 12 since v2 imports being used
+		# So, we know long form like "registry.terraform.io/hashicorp/null" given
+		if segment_count is 1 {
+			# Function was passed short form, so we want to reduce each occurence of
+			# r.provider_name to its short form.
+			resources = filter tfstate.resources as address, r {
+				strings.split(r.provider_name, "/")[2] is provider and
+					r.mode is "managed"
+			}
+		} else {
+			# Function was passed long form, so we use full r.provider_name
+			resources = filter tfstate.resources as address, r {
+				r.provider_name is provider and
+					r.mode is "managed"
+			}
+		} // end segment_count
+	} // end v_major
+
+	return resources
+}
+
+### find_datasources ###
+# Find all data sources of a specific type using the tfstate/v2 import.
+find_datasources = func(type) {
+	datasources = filter tfstate.resources as address, d {
+		d.type is type and
+			d.mode is "data"
+	}
+
+	return datasources
+}
+
+### find_datasources_by_provider ###
+# Find all data sources for a specific provider using the tfstate/v2 import.
+# Terraform 0.12 and earlier set `r.provider_name` to short text like "null";
+# but Terraform 0.13 and higher set it to something like
+# "registry.terraform.io/hashicorp/null".
+# You can pass in the long form or short form.
+find_datasources_by_provider = func(provider) {
+	parsed_provider = strings.split(provider, "/")
+	segment_count = length(parsed_provider)
+	v = strings.split(tfstate.terraform_version, ".")
+	v_major = int(v[1])
+
+	# If v_major is 12, we know short form was passed to Sentinel
+	if v_major is 12 {
+		datasources = filter tfstate.resources as address, r {
+			r.provider_name is provider and
+				r.mode is "data"
+		}
+	} else {
+		# v_major must be higher than 12 since v2 imports being used
+		# So, we know long form like "registry.terraform.io/hashicorp/null" given
+		if segment_count is 1 {
+			# Function was passed short form, so we want to reduce each occurence of
+			# r.provider_name to its short form.
+			datasources = filter tfstate.resources as address, r {
+				strings.split(r.provider_name, "/")[2] is provider and
+					r.mode is "data"
+			}
+		} else {
+			# Function was passed long form, so we use full r.provider_name
+			datasources = filter tfstate.resources as address, r {
+				r.provider_name is provider and
+					r.mode is "data"
+			}
+		} // end segment_count
+	} // end v_major
+
+	return datasources
+}
+
+### find_blocks ###
+# Find all blocks of a specific type from a resource using the tfstate/v2 import.
+# parent should be a single resource or block of a resource or a data source
+# or block of a data source.
+# If parent is a resource, you can pass it in the form r.values or just r.
+# child should be a string representing a block of parent
+# that contains a list of objects.
+find_blocks = func(parent, child) {
+	# Use parent.values if it exists
+	if (types.type_of(parent) is "map" and
+		"values" in keys(parent)) and
+		types.type_of(parent.values) is "map" {
+		if types.type_of(parent.values[child] else null) is "list" {
+			return parent.values[child]
+		} else {
+			return []
+		}
+	} else {
+		if types.type_of(parent[child] else null) is "list" {
+			return parent[child]
+		} else {
+			return []
+		}
+	}
+}
+
+### to_string ###
+# Convert objects of unknown type to string
+# It is used to build messages added to the messages map returned by the
+# filter functions
+to_string = func(obj) {
+	case types.type_of(obj) {
+		when "string":
+			return obj
+		when "int", "float", "bool":
+			return string(obj)
+		when "null":
+			return "null"
+		when "undefined":
+			return "undefined"
+		when "list":
+			output = "["
+			lastIndex = length(obj) - 1
+			for obj as index, value {
+				if index < lastIndex {
+					output += to_string(value) + ", "
+				} else {
+					output += to_string(value)
+				}
+			}
+			output += "]"
+			return output
+		when "map":
+			output = "{"
+			theKeys = keys(obj)
+			lastIndex = length(theKeys) - 1
+			for theKeys as index, key {
+				if index < lastIndex {
+					output += to_string(key) + ": " + to_string(obj[key]) + ", "
+				} else {
+					output += to_string(key) + ": " + to_string(obj[key])
+				}
+			}
+			output += "}"
+			return output
+		else:
+			return ""
+	}
+}
+
+### evaluate_attribute ###
+# Evaluates the value of a resource's or block's attribute even if nested.
+# The resource should be given in the initial call in the form
+# "r.values" where r is a resource derived by
+# applying filters to tfstate.resources.
+# Indices of lists should be given as 0, 1, 2, and so on.
+# For example: boot_disk.0.initialize_params.0.image
+evaluate_attribute = func(r, attribute) {
+
+	# Split the attribute into a list, using "." as the separator
+	attributes = strings.split(attribute, ".")
+
+	# Convert numeric strings to integers for indices
+	if attributes[0] matches "^[0-9]+$" {
+		a = int(attributes[0])
+		# Make sure r is of type list
+		if types.type_of(r) is not "list" {
+			return undefined
+		}
+	} else {
+		a = attributes[0]
+	}
+
+	# Append the current attribute to the resource instance
+	new_r = r[a] else null
+
+	# Append the current attribute to the resource instance
+	# We check if r is a map having `values` (also a map) and `module_address`, so
+	# that filter functions can pass in `r` instead of `r.values`.
+	# The extra check for `module_address` is meant to make sure that `r`
+	# is really a resource from the tfstate/v2 resources collection rather than
+	# some block which just happens to have a key called `values`.
+	# An example of such a block is the `filters` block of the `aws_ami` data source.
+	if types.type_of(r) is "map" and
+		"values" in keys(r) and
+		types.type_of(r.values) is "map" and
+		"module_address" in keys(r) {
+		new_r = r.values[a] else null
+	} else {
+		new_r = r[a] else null
+	}
+
+	# Process based on length of attributes
+	# being greater than or equal to 1
+	if length(attributes) > 1 {
+
+		# Strip first element from attributes
+		attributes = attributes[1:length(attributes)]
+		attribute = strings.join(attributes, ".")
+
+		# Make recursive call
+		return evaluate_attribute(new_r, attribute)
+	} else {
+
+		# We reached the end of the attribute and can stop the
+		# recursive calls and return the value of the attribute
+		return new_r
+
+	}
+}
+
+### print_violations ###
+# Prints violations returned by any of the filter functions defined below.
+# This would normally only be called if the filter function had been called
+# with prtmsg set to false, which is sometimes done when processing resources
+# and their blocks.
+# If the result of a filter function is assigned to a map like violatingIRs,
+# then you should pass violatingIRs["message"] as the first argument.
+# The prefix argument is printed before the message of each resource.
+print_violations = func(messages, prefix) {
+	for messages as address, message {
+		print(prefix, message)
+	}
+	return true
+}
+
+### filter_attribute_not_in_list ###
+# Filter a list of resources to those with a specified
+# attribute (attr) that is not in a given list of allowed values (allowed).
+# Resources should be derived by applying filters to tfstate.resources.
+# Set prtmsg to `true` (without quotes) if you want to print violation messages.
+# If you want to allow null, include "null" in the list (allowed).
+filter_attribute_not_in_list = func(resources, attr, allowed, prtmsg) {
+	violators = {}
+	messages = {}
+	for resources as address, r {
+		# Evaluate the value (v) of the attribute
+		v = evaluate_attribute(r, attr) else null
+		# Convert null to "null"
+		if v is null {
+			v = "null"
+		}
+		# Check if the value is not in the allowed list
+		if v not in allowed {
+			# Add the resource and a warning message to the violators list
+			message = to_string(address) + " has " + to_string(attr) + " with value " +
+				to_string(v) +
+				" that is not in the allowed list: " +
+				to_string(allowed)
+			violators[address] = r
+			messages[address] = message
+			if prtmsg {
+				print(message)
+			}
+		} // end if
+	} // end for
+	return {"items": violators, "messages": messages}
+}
+
+### filter_attribute_in_list ###
+# Filter a list of resources to those with a specified
+# attribute (attr) that is in a given list of forbidden values (forbidden).
+# Resources should be derived by applying filters to tfstate.resources.
+# Set prtmsg to `true` (without quotes) if you want to print violation messages.
+# If you want to disallow null, include "null" in the list (forbidden).
+filter_attribute_in_list = func(resources, attr, forbidden, prtmsg) {
+	violators = {}
+	messages = {}
+	for resources as address, r {
+		# Evaluate the value (v) of the attribute
+		v = evaluate_attribute(r, attr) else null
+		# Check if the value is null
+		if v is null {
+			v = "null"
+		}
+		# Check if the value is in the forbidden list
+		if v in forbidden {
+			# Add the resource and a warning message to the violators list
+			message = to_string(address) + " has " + to_string(attr) + " with value " +
+				to_string(v) +
+				" that is in the forbidden list: " +
+				to_string(forbidden)
+			violators[address] = r
+			messages[address] = message
+			if prtmsg {
+				print(message)
+			}
+		}
+	}
+	return {"items": violators, "messages": messages}
+}
+
+### filter_attribute_not_contains_list ###
+# Filter a list of resources to those with a specified
+# attribute (attr) that does not contain a given list of required values (required).
+# Set prtmsg to `true` (without quotes) if you want to print violation messages.
+# Resources should be derived by applying filters to tfstate.resources.
+filter_attribute_not_contains_list = func(resources, attr, required, prtmsg) {
+	violators = {}
+	messages = {}
+	for resources as address, r {
+		# Evaluate the value (v) of the attribute
+		v = evaluate_attribute(r, attr) else null
+		# Check if the value contains the desired allowed list
+		if v is null or
+			not (types.type_of(v) is "list" or types.type_of(v) is "map") {
+			# Add the resource and a warning message to the violators list
+			message = to_string(address) + " has " + to_string(attr) +
+				" that is missing, null, or is not a map or a list. " +
+				"It should have had these items: " +
+				to_string(required)
+			violators[address] = r
+			messages[address] = message
+			if prtmsg {
+				print(message)
+			}
+		} else {
+			missing_values = []
+			for required as rv {
+				if v not contains rv {
+					append(missing_values, rv)
+				} // end if
+			} // end for required
+			if length(missing_values) > 0 {
+				# Build warning message when v is a map
+				message = to_string(address) + " has " + to_string(attr) + " " +
+					to_string(v) +
+					" that is missing the required items " +
+					to_string(missing_values) +
+					" from the list: " +
+					to_string(required)
+				# Add the resource and warning message to the violators list
+				violators[address] = r
+				messages[address] = message
+				if prtmsg {
+					print(message)
+				}
+			} // end length(missing_values)
+		} // end else v not null
+	} // end for
+	return {"items": violators, "messages": messages}
+}
+
+### filter_attribute_contains_items_from_list ###
+# Filter a list of resources to those with a specified
+# attribute (attr) that contains any items from a given list of
+# forbidden values (forbidden).
+# Resources should be derived by applying filters to tfstate.resources.
+# Set prtmsg to `true` (without quotes) if you want to print violation messages.
+# If you want to disallow null, include "null" in the list (forbidden).
+filter_attribute_contains_items_from_list = func(resources, attr, forbidden, prtmsg) {
+	violators = {}
+	messages = {}
+	for resources as address, r {
+		# Evaluate the value (v) of the attribute
+		v = evaluate_attribute(r, attr) else null
+		# Check if the value contains the desired allowed list
+		if not (types.type_of(v) is "list" or types.type_of(v) is "map" or
+			types.type_of(v) is "null") {
+			# Add the resource and a warning message to the violators list
+			message = to_string(address) + " has " + to_string(attr) + " " +
+				to_string(v) +
+				" that is not a map, a list, or null"
+			violators[address] = r
+			messages[address] = message
+			if prtmsg {
+				print(message)
+			}
+		} else if v is null {
+			if "null" in forbidden {
+				# Add the resource and a warning message to the violators list
+				message = to_string(address) + " has " + to_string(attr) +
+					" with value null from the forbidden list: " +
+					to_string(forbidden)
+				violators[address] = r
+				messages[address] = message
+				if prtmsg {
+					print(message)
+				}
+			}
+		} else {
+			forbidden_values = []
+			for forbidden as fv {
+				if v contains fv {
+					append(forbidden_values, fv)
+				} // end if
+			} // end for forbidden
+			if length(forbidden_values) > 0 {
+				# Build warning message when v is a list
+				message = to_string(address) + " has " + to_string(attr) + " " +
+					to_string(v) +
+					" that has items " +
+					to_string(forbidden_values) +
+					" from the forbidden list: " +
+					to_string(forbidden)
+				# Add the resource and a warning message to the violators list
+				violators[address] = r
+				messages[address] = message
+				if prtmsg {
+					print(message)
+				}
+			} // end length(forbidden_values)
+		} // end v not null
+	} // end for
+	return {"items": violators, "messages": messages}
+}
+
+### filter_attribute_contains_items_not_in_list ###
+# Filter a list of resources to those with a specified
+# attribute (attr) that contains items not in a given list of allowed values.
+# Resources should be derived by applying filters to tfstate.resources.
+# Set prtmsg to `true` (without quotes) if you want to print violation messages.
+# If you want to allow null, include "null" in the list (allowed).
+filter_attribute_contains_items_not_in_list = func(resources, attr, allowed, prtmsg) {
+	violators = {}
+	messages = {}
+	for resources as address, r {
+		# Evaluate the value (vals) of the attribute
+		vals = evaluate_attribute(r, attr) else null
+		# Check if the value contains items not in allowed list
+		if not (types.type_of(vals) is "list" or types.type_of(vals) is "map" or
+			types.type_of(vals) is "null") {
+			# Add the resource and a warning message to the violators list
+			message = to_string(address) + " has " + to_string(attr) + " " +
+				to_string(vals) +
+				" that is not a map, a list, or null"
+			violators[address] = r
+			messages[address] = message
+			if prtmsg {
+				print(message)
+			}
+		} else if vals is null {
+			if "null" not in allowed {
+				# Add the resource and a warning message to the violators list
+				message = to_string(address) + " has " + to_string(attr) +
+					" with value null " +
+					"that is not in the allowed list: " +
+					to_string(allowed)
+				violators[address] = r
+				messages[address] = message
+				if prtmsg {
+					print(message)
+				}
+			}
+		} else {
+			forbidden_values = []
+			for vals as v {
+				if v not in allowed {
+					append(forbidden_values, v)
+				} // end if v not allowed
+			} // end for vals
+			if length(forbidden_values) > 0 {
+				# Build warning message when vals is a map
+				message = to_string(address) + " has " + to_string(attr) + " " +
+					to_string(vals) +
+					" with items " +
+					to_string(forbidden_values) +
+					" that are not in the allowed list: " +
+					to_string(allowed)
+				# Add the resource and a warning message to the violators list
+				violators[address] = r
+				messages[address] = message
+				if prtmsg {
+					print(message)
+				}
+			} // end length(forbidden_values)
+		} // end if null
+	} // end for
+	return {"items": violators, "messages": messages}
+}
+
+### filter_attribute_is_not_value ###
+# Filter a list of resources to those with a specified
+# attribute (attr) that does not have a given value.
+# Resources should be derived by applying filters to tfstate.resources.
+# Set prtmsg to `true` (without quotes) if you want to print violation messages.
+filter_attribute_is_not_value = func(resources, attr, value, prtmsg) {
+	violators = {}
+	messages = {}
+	for resources as address, r {
+		v = evaluate_attribute(r, attr) else null
+		if v is null {
+			# Add the resource and a warning message to the violators list
+			message = to_string(address) + " has " + to_string(attr) +
+				" that is null or undefined. " +
+				"It is supposed to be " +
+				to_string(value)
+			violators[address] = r
+			messages[address] = message
+			if prtmsg {
+				print(message)
+			}
+		} else if v is not value {
+			# Add the resource and a warning message to the violators list
+			message = to_string(address) + " has " + to_string(attr) + " with value " +
+				to_string(v) +
+				" that is not equal to " +
+				to_string(value)
+			violators[address] = r
+			messages[address] = message
+			if prtmsg {
+				print(message)
+			}
+		}
+	}
+	return {"items": violators, "messages": messages}
+}
+
+### filter_attribute_is_value ###
+# Filter a list of resources to those with a specified
+# attribute (attr) that has a given value.
+# Resources should be derived by applying filters to tfstate.resources.
+# Set prtmsg to `true` (without quotes) if you want to print violation messages.
+# If you want to match null, set value to "null".
+filter_attribute_is_value = func(resources, attr, value, prtmsg) {
+	violators = {}
+	messages = {}
+	for resources as address, r {
+		v = evaluate_attribute(r, attr) else null
+		if v is null {
+			v = "null"
+		}
+		if v is value {
+			# Add the resource and a warning message to the violators list
+			message = to_string(address) + " has " + to_string(attr) + " with value " +
+				to_string(v) +
+				" that is not allowed."
+			violators[address] = r
+			messages[address] = message
+			if prtmsg {
+				print(message)
+			}
+		}
+	}
+	return {"items": violators, "messages": messages}
+}
+
+### filter_attribute_greater_than_value ###
+# Filter a list of resources to those with a specified
+# attribute (attr) that is greater than a given numeric value.
+# Resources should be derived by applying filters to tfstate.resources.
+# Set prtmsg to `true` (without quotes) if you want to print violation messages.
+filter_attribute_greater_than_value = func(resources, attr, value, prtmsg) {
+	violators = {}
+	messages = {}
+	for resources as address, r {
+		v = evaluate_attribute(r, attr) else null
+		if float(v) else null is null {
+			# Add the resource and a warning message to the violators list
+			message = to_string(address) + " has " + to_string(attr) +
+				" that is null or undefined. " +
+				"It is supposed to be less " +
+				"than or equal to " +
+				to_string(value)
+			violators[address] = r
+			messages[address] = message
+			if prtmsg {
+				print(message)
+			}
+		} else if float(v) > value {
+			# Add the resource and a warning message to the violators list
+			message = to_string(address) + " has " + to_string(attr) + " with value " +
+				to_string(v) +
+				" that is greater than " +
+				to_string(value)
+			violators[address] = r
+			messages[address] = message
+			if prtmsg {
+				print(message)
+			}
+		}
+	}
+	return {"items": violators, "messages": messages}
+}
+
+### filter_attribute_less_than_value ###
+# Filter a list of resources to those with a specified
+# attribute (attr) that is less than a given numeric value.
+# Resources should be derived by applying filters to tfstate.resources.
+# Set prtmsg to `true` (without quotes) if you want to print violation messages.
+filter_attribute_less_than_value = func(resources, attr, value, prtmsg) {
+	violators = {}
+	messages = {}
+	for resources as address, r {
+		v = evaluate_attribute(r, attr) else null
+		if float(v) else null is null {
+			# Add the resource and a warning message to the violators list
+			message = to_string(address) + " has " + to_string(attr) +
+				" that is null or undefined. " +
+				"It is supposed to be greater " +
+				"than or equal to " +
+				to_string(value)
+			violators[address] = r
+			messages[address] = message
+			if prtmsg {
+				print(message)
+			}
+		} else if float(v) < value {
+			# Add the resource and a warning message to the violators list
+			message = to_string(address) + " has " + to_string(attr) + " with value " +
+				to_string(v) +
+				" that is less than " +
+				to_string(value)
+			violators[address] = r
+			messages[address] = message
+			if prtmsg {
+				print(message)
+			}
+		}
+	}
+	return {"items": violators, "messages": messages}
+}
+
+### filter_attribute_does_not_match_regex ###
+# Filter a list of resources to those with a specified
+# attribute (attr) that does not match a regular expression (expr).
+# Resources should be derived by applying filters to tfstate.resources.
+# Set prtmsg to `true` (without quotes) if you want to print violation messages.
+# If you want to allow null, set `expr` to "(<regex>|null)".
+filter_attribute_does_not_match_regex = func(resources, attr, expr, prtmsg) {
+	violators = {}
+	messages = {}
+	for resources as address, r {
+		v = evaluate_attribute(r, attr) else null
+		if v is null {
+			v = "null"
+		}
+		if v not matches expr {
+			# Add the resource and a warning message to the violators list
+			message = to_string(address) + " has " + to_string(attr) + " with value " +
+				to_string(v) +
+				" that does not match the regex " +
+				to_string(expr)
+			violators[address] = r
+			messages[address] = message
+			if prtmsg {
+				print(message)
+			}
+		}
+	}
+	return {"items": violators, "messages": messages}
+}
+
+### filter_attribute_matches_regex ###
+# Filter a list of resources to those with a specified
+# attribute (attr) that matches a regular expression (expr).
+# Resources should be derived by applying filters to tfstate.resources.
+# Set prtmsg to `true` (without quotes) if you want to print violation messages.
+# If you want to match null, set expr to "null".
+filter_attribute_matches_regex = func(resources, attr, expr, prtmsg) {
+	violators = {}
+	messages = {}
+	for resources as address, r {
+		v = evaluate_attribute(r, attr) else null
+		if v is null {
+			v = "null"
+		}
+		if v matches expr {
+			# Add the resource and a warning message to the violators list
+			message = to_string(address) + " has " + to_string(attr) + " with value " +
+				to_string(v) +
+				" that matches the regex " +
+				to_string(expr)
+			violators[address] = r
+			messages[address] = message
+			if prtmsg {
+				print(message)
+			}
+		}
+	}
+	return {"items": violators, "messages": messages}
+}
+
+### filter_attribute_does_not_have_prefix ###
+# Filter a list of resources to those with a specified
+# attribute (attr) that does not have a given prefix.
+# Resources should be derived by applying filters to tfstate.resources.
+# Set prtmsg to `true` (without quotes) if you want to print violation messages.
+filter_attribute_does_not_have_prefix = func(resources, attr, prefix, prtmsg) {
+	violators = {}
+	messages = {}
+	for resources as address, r {
+		v = evaluate_attribute(r, attr) else null
+		if v is null {
+			# Add the resource and a warning message to the violators list
+			message = to_string(address) + " has " + to_string(attr) +
+				" that is null or undefined. " +
+				"It must have a value that " +
+				"starts with " +
+				to_string(prefix)
+			violators[address] = r
+			messages[address] = message
+			if prtmsg {
+				print(message)
+			}
+		} else if not strings.has_prefix(v, prefix) {
+			# Add the resource and a warning message to the violators list
+			message = to_string(address) + " has " + to_string(attr) + " with value " +
+				to_string(v) +
+				" that does not have the prefix " +
+				to_string(prefix)
+			violators[address] = r
+			messages[address] = message
+			if prtmsg {
+				print(message)
+			}
+		}
+	}
+	return {"items": violators, "messages": messages}
+}
+
+### filter_attribute_has_prefix ###
+# Filter a list of resources to those with a specified
+# attribute (attr) that has a given prefix.
+# Resources should be derived by applying filters to tfstate.resources.
+# Set prtmsg to `true` (without quotes) if you want to print violation messages.
+filter_attribute_has_prefix = func(resources, attr, prefix, prtmsg) {
+	violators = {}
+	messages = {}
+	for resources as address, r {
+		v = evaluate_attribute(r, attr) else null
+		if v is null {
+			# Add the resource and a warning message to the violators list
+			message = to_string(address) + " has " + to_string(attr) +
+				" that is null or undefined. " +
+				"It must have a value that " +
+				"does not start with " +
+				to_string(prefix)
+			violators[address] = r
+			messages[address] = message
+			if prtmsg {
+				print(message)
+			}
+		} else if strings.has_prefix(v, prefix) {
+			# Add the resource and a warning message to the violators list
+			message = to_string(address) + " has " + to_string(attr) + " with value " +
+				to_string(v) +
+				" that has the prefix " +
+				to_string(prefix)
+			violators[address] = r
+			messages[address] = message
+			if prtmsg {
+				print(message)
+			}
+		}
+	}
+	return {"items": violators, "messages": messages}
+}
+
+### filter_attribute_does_not_have_suffix ###
+# Filter a list of resources to those with a specified
+# attribute (attr) that does not have a given suffix.
+# Resources should be derived by applying filters to tfstate.resources.
+# Set prtmsg to `true` (without quotes) if you want to print violation messages.
+filter_attribute_does_not_have_suffix = func(resources, attr, suffix, prtmsg) {
+	violators = {}
+	messages = {}
+	for resources as address, r {
+		v = evaluate_attribute(r, attr) else null
+		if v is null {
+			# Add the resource and a warning message to the violators list
+			message = to_string(address) + " has " + to_string(attr) +
+				" that is null or undefined. " +
+				"It must have a value that " +
+				"ends with " +
+				to_string(prefix)
+			violators[address] = r
+			messages[address] = message
+			if prtmsg {
+				print(message)
+			}
+		} else if not strings.has_suffix(v, suffix) {
+			# Add the resource and a warning message to the violators list
+			message = to_string(address) + " has " + to_string(attr) + " with value " +
+				to_string(v) +
+				" that does not have the suffix " +
+				to_string(suffix)
+			violators[address] = r
+			messages[address] = message
+			if prtmsg {
+				print(message)
+			}
+		}
+	}
+	return {"items": violators, "messages": messages}
+}
+
+### filter_attribute_has_suffix ###
+# Filter a list of resources to those with a specified
+# attribute (attr) that has a given suffix.
+# Resources should be derived by applying filters to tfstate.resources.
+# Set prtmsg to `true` (without quotes) if you want to print violation messages.
+filter_attribute_has_suffix = func(resources, attr, suffix, prtmsg) {
+	violators = {}
+	messages = {}
+	for resources as address, r {
+		v = evaluate_attribute(r, attr) else null
+		if v is null {
+			# Add the resource and a warning message to the violators list
+			message = to_string(address) + " has " + to_string(attr) +
+				" that is null or undefined. " +
+				"It must have a value that " +
+				"does not end with " +
+				to_string(suffix)
+			violators[address] = r
+			messages[address] = message
+			if prtmsg {
+				print(message)
+			}
+		} else if strings.has_suffix(v, suffix) {
+			# Add the resource and a warning message to the violators list
+			message = to_string(address) + " has " + to_string(attr) + " with value " +
+				to_string(v) +
+				" that has the suffix " +
+				to_string(suffix)
+			violators[address] = r
+			messages[address] = message
+			if prtmsg {
+				print(message)
+			}
+		}
+	}
+	return {"items": violators, "messages": messages}
+}

--- a/ebs-volume-must-be-encrypted.sentinel
+++ b/ebs-volume-must-be-encrypted.sentinel
@@ -1,0 +1,29 @@
+# This policy uses the Sentinel tfplan/v2 import to require that
+# all EBS volumes should be encrypted
+
+# Import common-functions/tfplan-functions/tfplan-functions.sentinel
+# with alias "plan"
+import "tfplan-functions" as plan
+
+# Get all EBS Volumes
+allEBSVolumes = plan.find_resources("aws_ebs_volume")
+
+# Get all Launch Templates
+allLaunchTemplates = plan.find_resources("aws_launch_template")
+
+# Filter to EBS volumes that are not encrypted
+# Warnings will be printed for all violations since the last parameter is true
+
+nonEncryptedEBSVolumes = plan.filter_attribute_is_not_value(allEBSVolumes,
+	"encrypted",
+	true, false)
+
+nonEncryptedEBSVolumesInLaunchTemplates = plan.filter_attribute_is_not_value(allLaunchTemplates,
+	"block_device_mappings.0.ebs.0.encrypted",
+	"true", false)
+
+# Main rule
+validated = length(nonEncryptedEBSVolumes["messages"]) is 0 and length(nonEncryptedEBSVolumesInLaunchTemplates["messages"]) is 0
+main = rule {
+	validated is true
+}

--- a/ecs-service-should-not-have-public-ip.sentinel
+++ b/ecs-service-should-not-have-public-ip.sentinel
@@ -1,0 +1,21 @@
+# This policy uses the Sentinel tfplan/v2 import to require that
+# all ecs service to have its network config to either be empty or not set to public
+
+# Import common-functions/tfplan-functions/tfplan-functions.sentinel
+# with alias "plan"
+import "tfplan-functions" as plan
+
+# Get all ECS services
+allECSService = plan.find_resources("aws_ecs_service")
+
+# Filter to AWS services that set to public ip
+# Warnings will be printed for all violations since the last parameter is true
+publicECSService = plan.filter_attribute_is_value(allECSService,
+	"network_configuration.0.assign_public_ip",
+	true, true)
+
+# Main rule - we want no public setting to be found
+public_found = length(publicECSService["messages"]) is 0
+main = rule {
+	public_found is true
+}

--- a/efs-filesystem-should-have-encryption-enabled.sentinel
+++ b/efs-filesystem-should-have-encryption-enabled.sentinel
@@ -1,0 +1,21 @@
+# This policy uses the Sentinel tfplan/v2 import to require that
+# all EFS filesystem resources created to be encrypted at creation
+
+# Import common-functions/tfplan-functions/tfplan-functions.sentinel
+# with alias "plan"
+import "tfplan-functions" as plan
+
+# Get all EFS filesystem
+allEFSFileSystem = plan.find_resources("aws_efs_file_system")
+
+# Filter to AWS services that set to public ip
+# Warnings will be printed for all violations since the last parameter is true
+unencryptedEFS = plan.filter_attribute_is_not_value(allEFSFileSystem,
+	"encrypted",
+	true, true)
+
+# Main rule - we want no public setting to be found
+validated = length(unencryptedEFS["messages"]) is 0
+main = rule {
+	validated is true
+}

--- a/elasticsearch-domains-encryption-must-be-enabled.sentinel
+++ b/elasticsearch-domains-encryption-must-be-enabled.sentinel
@@ -1,0 +1,26 @@
+# This policy uses the Sentinel tfplan/v2 import to require that
+# All elasticsearch domains are encrypted at rest and nodes encrypted end-to-end
+
+# Import common-functions/tfplan-functions/tfplan-functions.sentinel
+# with alias "plan"
+import "tfplan-functions" as plan
+
+# Get all cloudtrails
+allElasticDomains = plan.find_resources("aws_elasticsearch_domain")
+
+# Filter to elastic domains that are not encrypted
+# Warnings will be printed for all violations since the last parameter is true
+
+nonEncryptedElasticDomains = plan.filter_attribute_is_not_value(allElasticDomains,
+	"encrypt_at_rest.0.enabled",
+	true, false)
+
+nonEncryptedElasticDomainsNodes = plan.filter_attribute_is_not_value(allElasticDomains,
+	"node_to_node_encryption.0.enabled",
+	true, false)
+
+# Main rule
+validated = length(nonEncryptedElasticDomains["messages"]) is 0 and length(nonEncryptedElasticDomainsNodes["messages"]) is 0
+main = rule {
+	validated is true
+}

--- a/rds-must-be-encrypted.sentinel
+++ b/rds-must-be-encrypted.sentinel
@@ -1,0 +1,22 @@
+# This policy uses the Sentinel tfplan/v2 import to require that
+# All RDS resources have its storage encrypted
+
+# Import common-functions/tfplan-functions/tfplan-functions.sentinel
+# with alias "plan"
+import "tfplan-functions" as plan
+
+# Get all RDS resources
+allRDS = plan.find_resources("aws_db_instance")
+
+# Filter to elastic domains that are not encrypted
+# Warnings will be printed for all violations since the last parameter is true
+
+nonEncryptedRDS = plan.filter_attribute_is_not_value(allRDS,
+	"storage_encrypted",
+	true, false)
+
+# Main rule
+validated = length(nonEncryptedRDS["messages"]) is 0
+main = rule {
+	validated is true
+}

--- a/s3-should-have-encryption-enabled.sentinel
+++ b/s3-should-have-encryption-enabled.sentinel
@@ -1,0 +1,27 @@
+# This policy uses the Sentinel tfplan/v2 import to require that
+# all S3 buckets have ACL "private" and be encrypted by a KMS key
+
+# Import common-functions/tfplan-functions/tfplan-functions.sentinel
+# with alias "plan"
+import "tfplan-functions" as plan
+
+# Get all S3 bucket acls
+allS3BucketsServerSideEnc = plan.find_resources("aws_s3_bucket_server_side_encryption_configuration")
+
+# Filter to S3 buckets that are not encrypted by KMS
+# Warnings will be printed for all violations since the last parameter is true
+
+nonKMSEncryptedS3Buckets = plan.filter_attribute_is_not_value(allS3BucketsServerSideEnc,
+	"rule.0.apply_server_side_encryption_by_default.0.sse_algorithm",
+	"aws:kms", false)
+
+nonAESEncryptedS3Buckets = plan.filter_attribute_is_not_value(allS3BucketsServerSideEnc,
+	"rule.0.apply_server_side_encryption_by_default.0.sse_algorithm",
+	"AES256", false)
+
+# Main rule
+# validated = length(nonPrivateS3Buckets["messages"]) is 0 and length(nonEncryptedS3Buckets["messages"]) is 0
+validated = length(nonKMSEncryptedS3Buckets["messages"]) is 0 or length(nonAESEncryptedS3Buckets["messages"]) is 0
+main = rule {
+	validated is true
+}

--- a/sentinel.hcl
+++ b/sentinel.hcl
@@ -1,0 +1,43 @@
+module "tfplan-functions" {
+  source = "./common-functions/tfplan-functions/tfplan-functions.sentinel"
+}
+
+module "tfstate-functions" {
+  source = "./common-functions/tfstate-functions/tfstate-functions.sentinel"
+}
+
+module "tfconfig-functions" {
+  source = "./common-functions/tfconfig-functions/tfconfig-functions.sentinel"
+}
+
+module "aws-functions" {
+  source = "./aws-functions/aws-functions.sentinel"
+}
+
+policy "s3-should-have-encryption-enabled" {
+  source            = "./s3-should-have-encryption-enabled.sentinel"
+}
+
+policy "ecs-service-should-not-have-public-ip" {
+  source            = "./s3-should-have-encryption-enabled.sentinel"
+}
+
+policy "efs-filesystem-should-have-encryption-enabled" {
+  source            = "./efs-filesystem-should-have-encryption-enabled.sentinel"
+}
+
+policy "ebs-volume-must-be-encrypted" {
+  source            = "./ebs-volume-must-be-encrypted.sentinel"
+}
+
+policy "cloudtrail-encryption-must-be-enabled" {
+  source            = "./cloudtrail-encryption-must-be-enabled.sentinel"
+}
+
+policy "elasticsearch-domains-encryption-must-be-enabled" {
+  source            = "./elasticsearch-domains-encryption-must-be-enabled.sentinel"
+}
+
+policy "rds-must-be-encrypted" {
+  source            = "./rds-must-be-encrypted.sentinel"
+}


### PR DESCRIPTION
Include the following policies:

s3-should-have-encryption-enabled.sentinel
efs-filesystem-should-have-encryption-enabled.sentinel
ebs-volume-must-be-encrypted.sentinel
cloudtrail-encryption-must-be-enabled.sentinel
elasticsearch-domains-encryption-must-be-enabled.sentinel
rds-must-be-encrypted.sentinel